### PR TITLE
French translation of the Glossary

### DIFF
--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -193,99 +193,63 @@ En d'autres termes, c'est le processus d'augmentation ou d'atténuation des diff
 Ils comprennent des auteurs, des éditeurs, des artistes, des développeurs de logiciels, des activistes, et bien d'autres.
 
 **Format** (audio file)
-: Les types de fichiers sonores sous lesquels les sons sont enregistrés. Parmi les plus courants
-on trouve AIFF, WAV, FLAC, mp3 et Ogg Vorbis. 
+: Les types de fichiers sonores sous lesquels les sons sont enregistrés. Parmi les plus courants on trouve AIFF, WAV, FLAC, mp3 et Ogg Vorbis. 
 
-**fps**
-: Frames Per Second. Frame rate, or frame frequency is the frequency
-(rate) at which an imaging device produces unique consecutive images
-called frames. The term applies equally well to computer graphics, video
-cameras, film cameras, and motion capture systems. Frame rate is most
-often expressed in frames per second (FPS). 
+**ips** (fps)
+: Images par seconde. La fréquence d'images est la fréquence (taux) à laquelle un dispositif d'imagerie produit des images consécutives uniques. Le terme s'applique aussi bien aux images de synthèse qu'aux caméras vidéo, aux caméras cinématographiques et aux systèmes de capture de mouvement. La fréquence des images est le plus souvent exprimée en images par seconde (IPS ou FPS en anglais). 
 
-**Frequency**
-: Refers to the number of times an oscillation occurs in one second.
-Frequency is measured in **Hertz**, and is correlated to the **pitch**
-of a sound. Frequency is a **linear** scale, while pitch is
-**logarithmic**. The pitch 'A' above the middle C has a frequency of 440
-Hz. The 'A' one octave above is twice that frequency (880 Hz).
+**Fréquence**
+: Se réfère au nombre de fois qu'une oscillation se produit en une seconde.
+La fréquence est mesurée en **Hertz**, et est corrélée à la **hauteur** d'un son. La fréquence est une échelle **linéaire**, tandis que la hauteur est **logarithmique**.
+La hauteur "LA" au-dessus du do central a une fréquence de 440 Hz. Le "LA" situé une octave plus haut a une fréquence deux fois plus élevée (880 Hz).
 
 **Gain**
-: Increasing the **level**of an audio signal, usually measured using a
-**logarithmic** scale. See also **attenuation**.
+: Augmentation du **niveau** d'un signal audio, généralement mesurée à l'aide d'une échelle **logarithmique**. Voir également **atténuation**.
 
-**Grid**
-: The Grid is a system of points that a Region might snap to while editing
-it. The Grid can be "No Grid", "Grid" or "Magnetic". 
+**Grile**
+: La grille est un système de points sur lesquels une région peut s'accrocher lors de son édition. Le paramètre grille peut être réglé sur la valeur "Pas de grille", "Grille" ou "Magnétique".
 
-**Grid Points**
-: The points in the **Grid** which Regions will snap to when it is active.
-Grid Points may be minutes, seconds, video frames, bars, beats or some
-multiple of beats. 
+**Points de la grille**
+: Points de la **grille** sur lesquels les régions s'accrochent lorsqu'elles sont actives.
+Les points de la grille peuvent être des minutes, des secondes, des images vidéo, des mesures, des battements ou des multiples de battements.
 
 **Hertz**
-: A term used to describe the number of times something occurs in one
-second. In digital audio, it is used to describe the **sampling rate**,
-and in acoustics it is used to describe the **frequency** of a sound.
-Thousands of Herz are described as kHz (kilo Herz). 
+: Terme utilisé pour décrire le nombre de fois qu'une chose se produit en une seconde.
+En audio numérique, il est utilisé pour décrire le **taux d'échantillonnage**, et en acoustique, il est utilisé pour décrire la **fréquence** d'un son. Les milliers de Hertz sont appelés kHz (kilo Hertz). 
 
-**High Shelf**
-: In an **Equalizer**, a **Shelf** cuts or boosts everything above (High
-Shelf) or below (Low Shelf) a specific frequency.
+**Plateau haut**
+: Dans un **Égaliseur**, un **plateau** coupe ou augmente tout ce qui se trouve au-dessus (Haut) ou au-dessous (Bas) d'une fréquence spécifique.
 
 **Headroom**
-: The range of **Decibels** between the region's maximum **Peak**and the
-**Clipping Point** is commonly referred to as **Headroom**. It is common
-recording practice to keep approximately three to six Decibels of
-Headroom between the maximum of your signal and the Clipping Point.
+: La plage de **décibels** entre le **point culminant** de la région et le **point d'écrêtage** est communément appelée **headroom**. Il est courant d'enregistrer en conservant environ trois à six décibels de marge entre le maximum de votre signal et le point d'écrêtage.
 
 **Jack Audio Connection Kit (JACK)**
-: JACK is a low-latency audio system which manages connections between
-Ardour and the soundcard of your computer, and between Ardour and other
-JACK-enabled audio programs on your computer. You must install JACK for
-Linux or JackOSX before you can use Ardour.
+: JACK est un système audio à faible latence qui gère les connexions entre Ardour et la carte son de votre ordinateur, et entre Ardour et d'autres programmes audio de votre ordinateur compatibles avec JACK. Vous devez installer JACK pour Linux ou JackOSX avant de pouvoir utiliser Ardour.
 
 **JackOSX** (OS X)
-: The name of the version of **JACK** that runs on macOS. See **JACK**
-for more details. 
+: Le nom de la version de **JACK** qui fonctionne sur macOS. Voir **JACK** pour plus de détails.
 
 **JackPilot**
-: The control interface that comes with JackOSX. 
+: L'interface de contrôle fournie avec JackOSX. 
 
 **Jack Server**
-: The Jack Server is the "engine" or "backend" of the Jack Audio
-Connection Kit. 
+: Le serveur Jack est le "moteur" ou "backend" du kit de connexion Jack Audio.
 
 **Jack Router**
-: The Jack Router allows audio to be routed from one application to
-another using the **Jack Server**. 
+: Le routeur Jack permet d'acheminer l'audio d'une application à une autre à l'aide du **serveur Jack**.
 
 **JAMin**
-: JAMin is the Jack Audio Connection Kit Audio Mastering interface. JAMin
-is an open source application designed to perform professional audio
-mastering of stereo input streams. It uses **LADSPA** for digital signal
-processing (DSP).
+: JAMin est l'interface Jack Audio Connection Kit Audio Mastering. JAMin est une application open source conçue pour effectuer un mastering audio des flux d'entrée stéréo. Il utilise **LADSPA** pour le traitement du signal numérique (DSP).
 
-**LADSPA Plugins**
-: Linux Audio Developer Simple Plugin API (LADSPA) is a standard that
-allows software audio processors and effects to be plugged into a wide
-range of audio synthesis and recording packages. For instance, it allows
-a developer to write a reverb program and bundle it into a LADSPA
-"plugin library." Ordinary users can then use this reverb within any
-LADSPA-friendly audio application. Most major audio applications on
-Linux support LADSPA.
+**Greffons LADSPA**
+: Linux Audio Developer Simple Plugin API (LADSPA) est une norme qui permet de brancher des processeurs audio et des effets logiciels dans une large gamme de logiciels de synthèse et d'enregistrement audio. Par exemple, il permet à un développeur d'écrire un programme de réverbération et de le regrouper dans une "bibliothèque de greffons" LADSPA.
+Les utilisateurs ordinaires peuvent alors utiliser cette réverbération dans n'importe quelle application audio compatible avec LADSPA. La plupart des applications audio majeures sous
+Linux supportent LADSPA.
 
-**Latency**
-: Latency is the amount of time needed to process all the samples coming
-from sound applications on your computer and send it to the soundcard
-for playback, or to gather samples from the sound card for recording or
-processing. A shorter latency means you will hear the results quicker,
-giving the impression of a more responsive system. However, with a
-shorter latency you also run a greater risk of **glitches** in the audio
-because the computer might not have enough time to process the sound
-before sending it to the soundcard. A longer latency means fewer
-glitches, but at the price of a slower response time. Latency is
-measured in milliseconds.
+**Latence**
+: La latence est le temps nécessaire pour traiter tous les échantillons provenant des applications sonores sur votre ordinateur et les envoyer à la carte son et de les envoyer à la carte son pour la lecture, ou pour collecter les échantillons de la carte son pour l'enregistrement ou le traitement.
+Une latence plus courte signifie que vous entendrez les résultats plus rapidement, donnant l'impression d'un système plus réactif. Cependant, avec une latence plus courte, vous courez également un plus grand risque d'**artefacts** dans l'audio car l'ordinateur n'a peut-être pas assez de temps pour traiter le son avant de l'envoyer à la carte son. Une latence plus longue signifie moins d'artefacts mais au prix d'un temps de réponse plus lent. La latence est
+mesurée en millisecondes.
 
 **Limiting**
 : The process by which the amplitude of the output of a device is
@@ -296,7 +260,7 @@ prevented from exceeding a predetermined value.
 adding one (1, 2, 3, 4...), two (2, 4, 6, 8...) or ten (10, 20, 30,
 40...). Multiplying an audio signal, for example, by either a linear or
 a logarithmic scale will produce very different results. The scale of
-**frequency** is linear, while the scales of **pitch** and **gain** are
+**frequency** is linear, while the scales of **hauteur** and **gain** are
 logarithmic.
 
 **Linux kernel**
@@ -311,7 +275,7 @@ regardless of any edit operation performed.
 
 **Logarithmic**
 : A scale of numbers which progresses according to a certain ratio, such
-as exponentially (2, 4, 8, 16, 256...). Both scales of **pitch** and
+as exponentially (2, 4, 8, 16, 256...). Both scales of **hauteur** and
 **gain** are logarithmic, while the scale of **frequency** is linear.
 
 **Lossless**
@@ -362,7 +326,7 @@ controllers, computers and other electronic equipment to communicate,
 control, and synchronize with each other. MIDI allows computers,
 synthesizers, MIDI controllers, sound cards, samplers and drum machines
 to control one another, and to exchange system data. MIDI does not
-transmit audio signals, but simply messages such as note number (pitch),
+transmit audio signals, but simply messages such as note number (hauteur),
 velocity (intensity), note-on, and note-off.
 
 **Mixer Strip**
@@ -444,13 +408,13 @@ filtering.
 Region, and are located next to the Fader in the Mixer Window, and also
 in the Track Mixer, of each Track. 
 
-**Pitch**
-: Pitch represents the perceived fundamental frequency of a
+**hauteur**
+: hauteur represents the perceived fundamental frequency of a
 sound.^[](http://en.wikipedia.org/wiki/Pitch_(music)#cite_note-0)^^^It
 is one of the three major auditory attributes of sounds along with
-loudness and timbre. In MIDI, pitch is represented by a number between 0
+loudness and timbre. In MIDI, hauteur is represented by a number between 0
 and 127, with each number representing a key on a MIDI keyboard. The
-relation of pitch to **Frequency** is **Logarithmic**. This means that a
+relation of hauteur to **Frequency** is **Logarithmic**. This means that a
 sound which is heard as one **Octave**(+12 MIDI notes) above another one
 is twice the frequency in Hz, while a sound one octave below (-12 MIDI
 notes) is half the frequency.

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -252,172 +252,105 @@ Une latence plus courte signifie que vous entendrez les résultats plus rapideme
 mesurée en millisecondes.
 
 **Limiting**
-: The process by which the amplitude of the output of a device is
-prevented from exceeding a predetermined value.
+: Le processus par lequel l'amplitude de la sortie d'un appareil est empêchée de dépasser une valeur prédéterminée. 
 
 **Linear**
-: A scale of numbers which progresses in an additive fashion, such as by
-adding one (1, 2, 3, 4...), two (2, 4, 6, 8...) or ten (10, 20, 30,
-40...). Multiplying an audio signal, for example, by either a linear or
-a logarithmic scale will produce very different results. The scale of
-**frequency** is linear, while the scales of **hauteur** and **gain** are
-logarithmic.
+: Une échelle de nombres qui progresse de manière additive, par exemple en ajoutant un (1, 2, 3, 4...), deux (2, 4, 6, 8...) ou dix (10, 20, 30, 40...).
+La multiplication d'un signal audio, par exemple, par une échelle linéaire ou logarithmique produira des résultats très différents. L'échelle de **fréquence** est linéaire, alors que les échelles de **hauteur** et **gain** sont logarithmiques.
 
 **Linux kernel**
-: The core of the GNU/Linux operating system. In a **Real-time System**,
-this kernel is usually **Compiled**with new parameters which speed up
-the use of audio applications in the system. 
+: Le cœur du système d'exploitation GNU/Linux. Dans un **système en temps réel**, ce noyau est généralement **compilé** avec de nouveaux paramètres qui accélèrent l'utilisation des applications audio dans le système.
 
 **Lock Edit**
-: One of the three available **Edit Modes**, Lock Edit is similar to
-**Slice Edit**, but regions will remain at their original positions
-regardless of any edit operation performed.
+: L'un des trois **modes d'édition** disponibles, Lock Edit est similaire à **Slice Edit**, mais les régions restent dans leur position d'origine, quelle que soit l'opération d'édition effectuée.
 
 **Logarithmic**
-: A scale of numbers which progresses according to a certain ratio, such
-as exponentially (2, 4, 8, 16, 256...). Both scales of **hauteur** and
-**gain** are logarithmic, while the scale of **frequency** is linear.
+: Une échelle de nombres qui progresse selon un certain rapport, par exemple de manière exponentielle (2, 4, 8, 16, 256...). Les échelles de **hauteur** et de **gain** sont logarithmiques, tandis que l'échelle de **fréquence** est linéaire.
 
 **Lossless**
-: See **Compression** (data) 
+: Voir **Compression** (données) 
 
 **Lossy**
-: See Compression (data)
+: Voir Compression (Données)
 
 **Loudness**
-: Unlike **amplitude**, which expresses the physical power of a sound,
-loudness is the perceived strength of a sound. Tones at different
-frequencies may be perceived as being at different loudnesses, even if
-they are at the same amplitude.
+: Contrairement à l'**amplitude**, qui exprime la puissance physique d'un son, l'intensité sonore est la force perçue d'un son. Des sons de différentes fréquences peuvent être perçus comme ayant des intensités différentes, même s'ils ont la même amplitude.
 
 **LV2** 
-: LV2 is an open standard for plugins and matching host applications,
-mainly targeted at audio processing and generation. LV2 is a simple but
-extensible successor of LADSPA, intended to address the limitations of
-LADSPA which many applications have outgrown.
+: LV2 est une norme ouverte pour les greffons et les applications hôtes correspondantes, principalement destinés au traitement et à la génération audio.
+LV2 est un successeur simple mais extensible de LADSPA, destiné à remédier aux limites de LADSPA.
 
 **Main Canvas**
-: In the Editor Window of Ardour, the Main Canvas is the space just below
-the timeline rulers where Tracks and Busses are displayed horizontally.
+: Dans la fenêtre d'édition d'Ardour, le canevas principal est l'espace situé juste en dessous des règles de la ligne de temps où les pistes et les bus sont affichés horizontalement.
 
 **Master Out**
-: A master out is a bus to which all (or most) tracks and other busses
-send their output. It provides a convenient single point of control for
-the output of Ardour, and is a typical location for global effects.
-Master out use is enabled by default, and the master out bus is set up
-to be stereo.
+: Une sortie maître est un bus vers lequel toutes (ou la plupart) les pistes et autres bus envoient leur sortie. Il fournit un point de contrôle unique et pratique pour la sortie d'Ardour, et est un emplacement typique pour les effets globaux.
+L'utilisation de la sortie master est activée par défaut, et le bus de sortie master est configuré pour être stéréo.
 
 **Meter**
-: The grouping of strong and weak beats into larger units called bars or
-measures. 
+: Le regroupement des temps forts et faibles en unités plus grandes appelées mesures.
 
 **Mixing**
-: Audio mixing is the process by which a multitude of recorded sounds are
-combined into one or more channels, most commonly two-channel stereo. In
-the process, the levels, frequency content, dynamics and panoramic
-position of the source signals are commonly manipulated and effects such
-as reverb may be added. 
+: Le mixage audio est le processus par lequel une multitude de sons enregistrés sont combinés en un ou plusieurs canaux, le plus souvent en stéréo à deux canaux. Dans ce processus, les niveaux, le contenu en fréquence, la dynamique et la position panoramique des signaux sources sont généralement manipulés et des effets tels que la réverbération peuvent être ajoutés.
 
 **MIDI**
-: MIDI is an industry-standard protocol defined
-in^[](http://en.wikipedia.org/wiki/Musical_Instrument_Digital_Interface#cite_note-0)^
-1982 that enables electronic musical instruments such as keyboard
-controllers, computers and other electronic equipment to communicate,
-control, and synchronize with each other. MIDI allows computers,
-synthesizers, MIDI controllers, sound cards, samplers and drum machines
-to control one another, and to exchange system data. MIDI does not
-transmit audio signals, but simply messages such as note number (hauteur),
-velocity (intensity), note-on, and note-off.
+: MIDI est un protocole industriel standard défini en^[](http://en.wikipedia.org/wiki/Musical_Instrument_Digital_Interface#cite_note-0)^ 1982 qui permet aux instruments de musique électroniques tels que les claviers, les ordinateurs et autres équipements électroniques de communiquer, de contrôler et de se synchroniser les uns avec les autres. Le MIDI permet aux ordinateurs, synthétiseurs, contrôleurs MIDI, cartes son, échantillonneurs et boîtes à rythmes de se contrôler mutuellement et d'échanger des données système. Le MIDI ne transmet pas de signaux audio, mais simplement des messages tels que le numéro de la note (hauteur), vélocité (intensité), note-on et note-off.
 
 **Mixer Strip**
-: Each track and bus is represented in the Mixer Window by a vertical
-Mixer Strip** that contains various controls related to signal flow.
-There are two places in Ardour in which you can see mixer strips. The
-mixer window is the obvious one, but you can also view a single mixer
-strip on the left hand side of the Editor (shift + E to hide/view) 
+: Chaque piste et chaque bus est représenté dans la fenêtre du mixeur par une bande de mixage** verticale qui contient diverses commandes liées au flux du signal.
+Il y a deux endroits dans Ardour où vous pouvez voir des bandes de mixage. La fenêtre du mixeur est l'endroit le plus évident, mais vous pouvez aussi en voir une seule sur le côté gauche de l'éditeur (shift + E pour cacher/afficher).
 
 **Mixer Window**
-: The Mixer shows the session by representing tracks vertically as Mixer
-Strips, with controls for gain, record enable, soloing, plugins etc. The
-Mixer represents the signal flow of Tracks and Busses in an Ardour
-session. The mixer window provides a view that mimics a traditional
-hardware mixing console.
+: La table de mixage présente la session en représentant les pistes verticalement sous forme de Mixer avec des contrôles pour le gain, l'activation de l'enregistrement, la mise en solo, les greffons, etc. Le Mixer représente le flux de signal des pistes et des bus dans une session Ardour. La fenêtre du mixeur offre une vue qui imite une console de mixage traditionnelle.
 
 **Monitoring**
-: Monitoring is the process of routing a specific mix or submix of your
-session into separate outputs (like headphones). For example, a musician
-being recorded may want to listen to existing material while performing.
-Ardour and JACK make it easy to setup monitor outs since any incoming
-signal can then be delivered back to any output, optionally mixed
-together with other signals and with any kind of sound processing added.
+: Le monitoring consiste à acheminer un mixage ou un sous-mixage spécifique de votre session vers des sorties séparées (comme un casque). Par exemple, un musicien en cours d'enregistrement peut vouloir écouter le matériel existant pendant qu'il joue. Ardour et JACK facilitent la mise en place de sorties de contrôle, car tout signal entrant peut être renvoyé vers n'importe quelle sortie, éventuellement mixé avec d'autres signaux et avec n'importe quel type de traitement sonore ajouté.
 
 **Mono**
-: A mono sound file contains only one channel of audio. A mono track in
-Ardour has only one input and handles mono sound files. 
+: Un fichier audio mono ne contient qu'un seul canal audio. Une piste mono dans Ardour n'a qu'une seule entrée et gère les fichiers sonores mono.
 
 **MP3**
-: A lossy, size-compressed sound file **Format**. 
+: Un **Format** de fichier son avec perte, compressé en taille. 
 
 **Graphic Equalizer/Multi-Band Equalizer**
-: A Graphic (or Multi-Band) Equalizer consists of a bank of sliders for
-boosting or attenuating different frequency of a sound. 
+: Un égaliseur graphique (ou multibande) est constitué d'une banque de curseurs permettant de
+d'augmenter ou d'atténuer les différentes fréquences d'un son.
 
 **Non-destructive Editing/Recording**
-: This is a form of editing where the original content is not modified in
-the course of editing. Behind the scenes, the original sound file is
-kept intact, and your edits are in fact a list of instructions that
-Ardour will use in order to reconstruct the signal from the original
-source when you play it back. For example, creating fade-ins and
-fade-outs on your Regions is a type of non-destructive editing. 
+: Il s'agit d'une forme d'édition où le contenu original n'est pas modifié au cours du montage. En coulisses, le fichier son original est conservé intact, et vos éditions sont en fait une liste d'instructions qu'Ardour utilisera pour reconstruire le signal de la source originale lorsque vous l'écouterez. Par exemple, la création de fade-ins et de fade-outs sur vos régions est un type d'édition non destructive.
 
 **Normalize**
-: To normalize an audio signal means to adjust its **Gain** so that it
-peaks at the maximum the sound card allows before **Clipping**.
+: Normaliser un signal audio signifie ajuster son **gain** de façon à ce qu'il atteigne le maximum autorisé par la carte son avant **écrêtage**.
 
 **Normal Mode**
-: See **Track Mode**. 
+: Voir **Track Mode**. 
 
 **Note value**
-: The proportional duration of a note or rest in relation to a standard
-unit. For instance, a 'quarter note' (crotchet) is so-called because its
-relative duration is one quarter of a whole note (semibreve). 
+: Durée proportionnelle d'une note ou d'un silence par rapport à une unité standard.
+unité standard. 
 
 **Octave** (music) 
-: A distance of 12 semitones between two notes. In **Hertz**, the ratio of
-an octave is 2:1. For example, the note 'A' above the middle C has a
-frequency of 440 Hz. The note 'A' one octave above is 880 Hz, and one
-octave below is 220 Hz. 
+: Distance de 12 demi-tons entre deux notes. Dans **Hertz**, le rapport d'une octave est de 2:1. Par exemple, la note "La" au-dessus du do moyen a une fréquence de 440 Hz.
+La note "La" une octave au-dessus a une fréquence de 880 Hz, et une octave en dessous a une fréquence de 220 Hz.
 
 **Ogg Vorbis**
-: An open source lossy, size-compressed sound file format. 
+: Un Format de fichier son libre avec perte, compressé en taille.
 
 **Panning**
-: Panning is the location of sounds in the **Stereo Field**. 
+: Le panoramique est l'emplacement des sons dans le **champ stéréo**. 
 
 **Parametric Equalizer**
-: The Parametric Equalizer is the most versatile type of**EQ** used for
-**Mixing** because of its extensive control over all the parameters of
-filtering. 
+: L'égaliseur paramétrique est le type d'égaliseur** le plus polyvalent utilisé pour le **mixage** car il permet un contrôle étendu de tous les paramètres de filtrage. 
 
 **Peaks**
-: Peaks are a graphical representation of the maximum **Levels** of a
-**Region**. 
+: Les crêtes sont une représentation graphique des **niveaux** maximums d'une **région**. 
 
 **Peak Meters**
-: Peak Meters are a running representation of the maximum Levels of a
-Region, and are located next to the Fader in the Mixer Window, and also
-in the Track Mixer, of each Track. 
+: Les crête-mètres représentent les niveaux maximums d'une région et sont situés à côté de l'atténuateur dans la fenêtre du mixeur mais aussi dans le mixeur de piste de chaque piste.
 
-**hauteur**
-: hauteur represents the perceived fundamental frequency of a
-sound.^[](http://en.wikipedia.org/wiki/Pitch_(music)#cite_note-0)^^^It
-is one of the three major auditory attributes of sounds along with
-loudness and timbre. In MIDI, hauteur is represented by a number between 0
-and 127, with each number representing a key on a MIDI keyboard. The
-relation of hauteur to **Frequency** is **Logarithmic**. This means that a
-sound which is heard as one **Octave**(+12 MIDI notes) above another one
-is twice the frequency in Hz, while a sound one octave below (-12 MIDI
-notes) is half the frequency.
+**Hauteur**
+: La hauteur représente la fréquence fondamentale perçue d'un son.
+^[](http://en.wikipedia.org/wiki/Pitch_(music)#cite_note-0)^^Il est l'un des trois principaux attributs auditifs des sons, avec l'intensité la sonorité et le timbre. En MIDI, la hauteur est représentée par un nombre compris entre 0 et 127, chaque chiffre représentant une touche d'un clavier MIDI. La relation entre la hauteur et la **fréquence** est **logarithmique**. Cela signifie qu'un son qui est entendu une **Octave** (+12 notes MIDI) au-dessus d'un autre son est le double de la fréquence en Hz, tandis qu'un son une octave plus bas (-12 notes MIDI) correspond à la moitié de la fréquence.
 
 **Tête de lecture**
 : Dans Ardour, la tête de lecture est la ligne rouge qui se déplace dans le temps (c'est-à-dire de gauche à droite) pour indiquer la position de lecture actuelle.

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -66,15 +66,10 @@ Les signaux audio ayant une amplitude plus élevée ont généralement un son pl
 : La pulsation de base d'un morceau de musique.
 
 **Beats per Minute**
-: Beats per minute (BPM) is a measure of tempo in music. A rate of 60
-beats per minute means that one beat will occur every second; 120 bpm
-equals two beats per second, and so on. BPM indications usually appear
-at the beginning of a traditional musical score as a metronome mark (for
-example, "quarter note equals 60", meaning one quarter note per second).
+: Les battements par minute (BPM) sont une mesure du tempo en musique. Un rythme de 60 battements par minute signifie qu'un battement se produit toutes les secondes ; 120 bpm équivaut à deux battements par seconde, et ainsi de suite. Les indications de BPM apparaissent généralement au début d'une partition musicale traditionnelle sous la forme d'une marque de métronome (par exemple, "la noire égale 60", ce qui signifie une noire par seconde).
 
 **Bit**
-: A bit (**bi**nary dig**it**) is a single number with a value of either 0
-or 1. 
+: Un bit (**bi**nary dig**it**) est un nombre unique dont la valeur est soit 0 soit 1. 
 
 **Bit Depth**
 : Refers to the number of bits used to write a _sample_. In the CD

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -121,62 +121,37 @@ Il peuvent affiche le temps dans un certain nombre de formats : _Timecode_, _Bar
 les parties les plus bruyantes. Cela entraîne une réduction de la plage dynamique réelle : un son compressé est moins dynamique.
 
 **Compression** (data)
-: Like any other data, audio data can be compressed so that it uses less
-hard disk space. Compression such as FLAC, ALAC, or MLP reduce the size
-of audio files compared to WAV or AIFF without changing the data, which
-is referred to as lossless compression. Audio can be compressed to a
-still smaller size by using lossy compression such as MP3, Ogg Vorbis or
-AAC but this is achieved by removing data which can have an audible
-effect. 
+: Comme toutes les autres données, les données audio peuvent être compressées de manière à utiliser moins d'espace sur le disque dur.
+La compression telle que FLAC, ALAC ou MLP réduit la taille des fichiers audio par rapport à WAV ou AIFF sans modifier les données, ce que l'on appelle la compression sans perte. L'audio peut être compressé à une taille encore plus petite en utilisant la compression avec perte comme le MP3, l'Ogg Vorbis ou l'AAC, mais cela se fait en supprimant des données qui peuvent avoir un effet audible.
 
 **Connections Manager**(JACK)
-: The window in Jack that allows to manage all connections between audio
-inputs and outputs.
+: La fenêtre dans JACK qui permet de gérer toutes les connexions entre les entrées et les sorties audio.
 
 **CoreAudio**(macOS)
-: CoreAudio provides audio functionality to the macOS operating system.
+: CoreAudio fournit des fonctionnalités audio au système d'exploitation macOS.
 
 **Cursor Modes**
-: These are the six buttons just below the Transport commands in the
-Editor Window. The six different functions that the mouse pointer can
-have in Ardour are: Select/Move Objects, Select/Move Ranges, Select Zoom
-Range, Draw Gain Automation, Stretch/Shrink Regions, Listen to Specific
-Regions.
+: Il s'agit des six boutons situés juste en dessous des commandes de transport dans la fenêtre de l'éditeur. Les six fonctions différentes que le pointeur de la souris peut avoir dans Ardour sont les suivantes : Sélectionner/déplacer des objets, Sélectionner/déplacer des intervalles, Sélectionner la plage de zoom, dessiner l'automatisation du gain, étirer/rétrécir les régions, écouter des régions spécifiques.
 
 **Decibels**
-: Decibel is a logarithmic scale used to measure many quantities,
-including the gain_, level_ or loudness_ of a signal. Decibel
-is usually abbreviated to dB and in digital audio usually denotes how
-far under 0 dBFS (the clipping_ point of a system) a signal is. 
+: Le décibel est une échelle logarithmique utilisée pour mesurer de nombreuses quantités, y compris le gain, le niveau ou l'intensité sonore d'un signal. Le décibel est généralement abrégé en dB et, dans le domaine de l'audio numérique, il indique généralement à quelle distance de 0 dBFS (le point d'écrêtage d'un système).
 
-**Delay** (effect)
-: The amount of time between one event and another. As an audio effect, a delay
-takes an incoming sound signal and delays it for a certain length of time. When
-mixed with the original sound, an "echo" is heard. By using _feedback_ to return
-the delayed signal back into the delay (usually after lowering its _gain_),
-multiple echos with a _decay_ result.
+**Delay** (effet)
+: Temps qui s'écoule entre un événement et un autre. En tant qu'effet audio, un délai prend un signal sonore entrant et le retarde pendant un certain temps. Lorsqu'il est mélangé au son original, on entend un "écho". En utilisant le _feedback_ pour renvoyer
+le signal retardé dans le délai (généralement après avoir baissé son _gain_), on obtient des échos multiples avec une _décroissance_.
 
 **Destructive Editing/Recording**
-: Destructive actions are those that permanently modify or erase the original
-data (sound files) in the course of editing or recording. 
+: Les actions destructives sont celles qui modifient ou effacent de façon permanente les données originales (fichiers sonores) au cours de l'édition ou de l'enregistrement.
 
-**Distortion** : Distortion occurs when an audio signal is changed in some way
-that produces _frequencies_ not present in the original. Distortion can be
-deliberate or unwanted, and can be produced by driving the signal to a
-_clipping_point_, or by using mathematical transformations to alter the shape (or
-"waveform") of the signal (usually referred to as "waveshaping").
+**Distortion**
+: La distorsion se produit lorsqu'un signal audio est modifié d'une manière ou d'une autre qui produit des _fréquences_ absentes de l'original. La distorsion peut être délibérée ou non, et peut être produite en conduisant le signal à un _point d'écrêtage_, ou en utilisant des transformations mathématiques pour modifier la forme (ou "forme d'onde") du signal (généralement appelée "mise en forme d'onde").
 
 **Disk Image (.dmg)**
-: A disk image is a single file containing the complete contents and
-structure representing a data storage medium or device. By
-double-clicking on a .dmg file on a Mac, a virtual device will be
-mounted to your Desktop (it will look as if you had inserted a USB
-device or a DVD, for example). Many software installers in OS X are
-available as .dmg files. 
+: Une image de disque est un fichier unique de l'intégralité du contenu et de la structure d'un support ou d'un périphérique de stockage de données. En double-cliquant sur un fichier .dmg sur un Mac, un périphérique virtuel sera monté sur votre bureau (comme si vous aviez inséré un périphérique USB ou un DVD, par exemple). De nombreux programmes d'installation de logiciels sous OS X sont
+sont disponibles sous forme de fichiers .dmg.
 
 **Driver**(JACK)
-: Software written to control hardware. CoreAudio is the Mac sound driver.
-ALSA is the most common Linux driver.
+: Logiciel écrit pour contrôler le matériel. CoreAudio est le pilote de son pour Mac. ALSA est le pilote Linux le plus courant.
 
 **DSP**
 : Digital Signal Processing.

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -1,0 +1,789 @@
++++
+title = "Glossaire"
+description = "Terminologie utilisée dans ce tutoriel Ardour"
+chapter = false
+weight = 2
++++
+
+Ce glossaire propose de brèves définitions pour de nombreux termes utilisés dans le tutoriel Ardour3 FLOSS.
+
+**Aggregate Device** (macOS)
+: Un dispositif agrégé est une carte son virtuelle composée de deux cartes son physiques ou plus.
+Les PowerBooks et les MacBooks fabriqués en 2007 ou plus tard auront besoin de cette configuration pour que _JACK_ ait des canaux d'entrée et de sortie. Cette configuration se fait dans l'application _Audio MIDI Setup_.
+
+**AIFF**
+: Format de fichier audio développé par Apple et couramment utilisé pour le son sans perte et sans compression. Les fichiers AIFF sont compatibles avec les systèmes d'exploitation Windows, Macintosh et Linux.
+
+**ALSA** (Linux)
+: Advanced Linux Sound Architecture. ALSA fournit des fonctionnalités audio et MIDI au système d'exploitation Linux.
+
+**Amplitude** (mixage)
+: La force d'un signal audio. L'échelle de l'amplitude est _*logarithmique_, puisqu'elle exprime le rapport physique de puissance entre un son et un autre. Dans les systèmes audio numériques, les niveaux sont généralement représentés par le nombre de décibels en dessous du point d'écrêtage de 0 dB.
+Voir également _loudness_.
+
+**Arm** (Piste à enregistrer/Ardour pour enregistrement)
+: Action qui permet à Ardour de commencer l'enregistrement. Avant d'enregistrer dans Ardour, il faut d'abord armer une ou plusieurs pistes, puis armer Ardour.
+
+**Artifacts** (sound)
+: Distorsion perceptible ou diminution de la qualité du son générée en tant que sous-produit de certaines opérations de traitement du signal. Les artefacts sont généralement considérés comme des résultats indésirables ou inattendus d'une transformation sonore par ailleurs intentionnelle.
+
+**Attenuation**
+: Réduire le **niveau** d'un signal audio, généralement mesuré à l'aide d'une échelle _logarithmique_.
+Voir aussi _gain_.
+
+**Audio MIDI Setup** (macOS)
+: L'utilitaire Audio MIDI Setup est un programme fourni avec le système d'exploitation macOS pour ajuster les paramètres de configuration de l'entrée et de la sortie audio de l'ordinateur et gérer les périphériques MIDI.
+
+**Audio Unit Plugins**
+: Audio Unit (AU) est une architecture de greffons dans les ordinateurs macOS. Il peut comme l'équivalent pour Apple du format de greffons VST de Steinberg. MacOS est livré avec une collection de greffons AU tels que l'égaliseur, des filtres, des processeurs dynamiques, des délais, des réverbérations, des étirements temporels, entre autres.
+
+**Audition**
+: L'auditeur est une bande de mixage cachée qui permet de lire des régions jouées par son intermédiaire. L'audition d'une région ne joue que cette région, sans traitement ni greffons.
+
+**Automation**
+: L'automatisation est l'ajustement automatique de divers paramètres tels que le gain, le panoramique ou les réglages des greffons.
+Les changements peuvent être effectués une fois et seront ensuite répétés à chaque fois que le mixage sera rejoué.
+Dans Ardour, l'automatisation est contrôlée par des lignes d'automatisation liées à chaque piste ou bus.
+
+**Auxiliary Controls**
+: Boutons situés en haut à droite des commandes de l'éditeur.
+Fenêtre : Punch In/Out, Auto Play, Auto Return, Auto Input, Click, Solo et Audition.
+
+**Amplitude**
+: Le niveau ou l'ampleur d'un signal.
+Les signaux audio ayant une amplitude plus élevée ont généralement un son plus fort.
+
+**Bands** (egalisation)
+: Les régions de fréquences particulières à amplifier ou à atténuer dans le processus d'égalisation.
+
+**Bars** (musique)
+: La barre de mesure est une unité métrique. Dans la notation occidentale, c'est l'espace compris entre deux lignes verticales tracées sur la portée. La durée spécifique d'une mesure dépend de sa _signature temporelle_ et du _tempo_ actuel de la musique.
+
+**Bass** (Fréquences)
+: Une manière générique de se référer aux basses fréquences du _spectre_ d'un son.
+
+**Beat**
+: La pulsation de base d'un morceau de musique.
+
+**Beats per Minute**
+: Beats per minute (BPM) is a measure of tempo in music. A rate of 60
+beats per minute means that one beat will occur every second; 120 bpm
+equals two beats per second, and so on. BPM indications usually appear
+at the beginning of a traditional musical score as a metronome mark (for
+example, "quarter note equals 60", meaning one quarter note per second).
+
+**Bit**
+: A bit (**bi**nary dig**it**) is a single number with a value of either 0
+or 1. 
+
+**Bit Depth**
+: Refers to the number of bits used to write a _sample_. In the CD
+standard, each sample of audio is represented by a 16-bit number. This
+gives 2\^16 (two to the power of sixteen = 65,536) possible values that
+a sample can have. A higher bit depth means a greater possible _dynamic
+range_. Studio recordings are usually first made recorded with a bit
+depth of 24 (or even 32) to preserve as much detail before transfer to
+CD. DVDs are made at 24 bit, while video games from the 1980s remain
+famous for their distinctively rough "8 bit sound". Bit depth is also
+referred to as **word length**. 
+
+**Buffer Size** (JACK)
+: The buffer is a section of memory specifically allotted to temporary
+signal data. Small buffer sizes allow a lower latency and so are needed
+when using audio applications that require real-time interaction. The
+drawback is that CPU consumption for the system is higher with smaller
+buffer sizes. Larger buffers (like 512 or 1024) can be used when there
+is no such requirement.
+
+**Built-in Input and Output**
+: These are the default interfaces for getting sound in and out of your
+computer if you don't have an external sound card. In a laptop, they are
+the common input (mic) and output (headphone) connections.
+
+**Bus**
+: A bus is similar to a track except that it does not contain its
+own regions. You cannot record directly into a bus or drag regions into
+it. The _Mixer_ strip vertically represents the signal flow of a bus,
+whereas the Main Canvas horizontally displays time-based information for
+each bus (such as automation lines).
+
+**BWF**
+: Broadcast Wave Format (BWF) is an extension of the popular Microsoft
+WAVE audio format and is the recording format of most file-based
+non-linear digital recorders used for motion picture and television
+production. This file format allows the inclusion of metadata to
+facilitate the seamless exchange of sound data between different
+computer platforms and applications.
+
+**CAF**
+: CAF (Core Audio Format) is a file format for storing audio, developed by
+Apple. It is compatible with macOS 10.4 and higher. The Core Audio
+Format is designed to overcome limitations of older digital audio
+formats, including AIFF and WAV. Just like the QuickTime .mov file
+format, a .caf file format can contain many different audio formats,
+metadata tracks, and much more data.
+
+**Center Frequency**
+: In some EQ plugins, the user has the possibility of choosing the center
+frequency for each of the frequency bands. The center frequency of a
+Band will be the one most sharply attenuated or reinforced by the
+equalizer for that specific band. Frequencies surrounding the center
+frequency will be less affected. 
+
+**Click** (Mouse)
+: In this manual, it specifically means to click on the left button of
+your mouse. Whenever the right button is required, the action is
+referred to as "right-click".
+
+**Clipping**
+: Clipping occurs when a signal is too high in level to be reproduced. Any
+samples too high in level will simply be truncated, resulting in
+_distortion_, loss of audio detail, and artefact _frequencies_ which
+were not present in the original sound.
+
+**Clipping Point**
+: The clipping point of a digital system is referred to as 0 dB, and
+the level of any sound is measured in how far below the clipping point
+it is (-10 dB, -24 dB, etc).
+
+**Clocks**
+: The two big numerical displays near the top of the _Editor_ window. They can
+display the time in a number of formats: _Timecode_, _Bars:Beats_,
+_Minutes:Seconds_, and _Samples_.
+
+**Compile**
+: FLOSS applications are distributed as source code, which is human-readable but
+cannot be run as an actual application. To turn this source code into a running
+application, it must first be Compiled. When you download a disk image for macOS
+or a software package from your distribution (such as Ubuntu, Debian or Fedora),
+it has been compiled for you already. However, if you wish to add features (such
+as support for _VST Plugins_) which your distribution does not provide, then
+you must compile the application from source code yourself. 
+
+**Compression**(DSP)
+: Essentially, compression makes the quiet parts of a signal louder
+without changing the level of 
+the louder parts. This entails a reduction of the actual dynamic range:
+a compressed sound is less dynamic (has a smaller range of levels) 
+
+**Compression** (data)
+: Like any other data, audio data can be compressed so that it uses less
+hard disk space. Compression such as FLAC, ALAC, or MLP reduce the size
+of audio files compared to WAV or AIFF without changing the data, which
+is referred to as lossless compression. Audio can be compressed to a
+still smaller size by using lossy compression such as MP3, Ogg Vorbis or
+AAC but this is achieved by removing data which can have an audible
+effect. 
+
+**Connections Manager**(JACK)
+: The window in Jack that allows to manage all connections between audio
+inputs and outputs.
+
+**CoreAudio**(macOS)
+: CoreAudio provides audio functionality to the macOS operating system.
+
+**Cursor Modes**
+: These are the six buttons just below the Transport commands in the
+Editor Window. The six different functions that the mouse pointer can
+have in Ardour are: Select/Move Objects, Select/Move Ranges, Select Zoom
+Range, Draw Gain Automation, Stretch/Shrink Regions, Listen to Specific
+Regions.
+
+**Decibels**
+: Decibel is a logarithmic scale used to measure many quantities,
+including the gain_, level_ or loudness_ of a signal. Decibel
+is usually abbreviated to dB and in digital audio usually denotes how
+far under 0 dBFS (the clipping_ point of a system) a signal is. 
+
+**Delay** (effect)
+: The amount of time between one event and another. As an audio effect, a delay
+takes an incoming sound signal and delays it for a certain length of time. When
+mixed with the original sound, an "echo" is heard. By using _feedback_ to return
+the delayed signal back into the delay (usually after lowering its _gain_),
+multiple echos with a _decay_ result.
+
+**Destructive Editing/Recording**
+: Destructive actions are those that permanently modify or erase the original
+data (sound files) in the course of editing or recording. 
+
+**Distortion** : Distortion occurs when an audio signal is changed in some way
+that produces _frequencies_ not present in the original. Distortion can be
+deliberate or unwanted, and can be produced by driving the signal to a
+_clipping_point_, or by using mathematical transformations to alter the shape (or
+"waveform") of the signal (usually referred to as "waveshaping").
+
+**Disk Image (.dmg)**
+: A disk image is a single file containing the complete contents and
+structure representing a data storage medium or device. By
+double-clicking on a .dmg file on a Mac, a virtual device will be
+mounted to your Desktop (it will look as if you had inserted a USB
+device or a DVD, for example). Many software installers in OS X are
+available as .dmg files. 
+
+**Driver**(JACK)
+: Software written to control hardware. CoreAudio is the Mac sound driver.
+ALSA is the most common Linux driver.
+
+**DSP**
+: Digital Signal Processing.
+
+**Dynamic Range**
+: Used to refer to the difference between the loudest and the quietest
+sound that can possibly recorded, as well as the amount of detail which
+can be heard in between those extremes. Sounds which are too quiet to be
+recorded are said to be below the **noise floor**of the recording system
+(microphone, recorder, sound card, audio software, etc). Sounds which
+are too loud will be **distorted**or **clipped**. 
+
+**Edit** **Modes**
+: The three available Edit Modes (**Slide Edit**, **Slice Edit**, and
+**Lock Edit**) control the behavior of editing operations in the **Main
+Canvas**.
+
+**Edit Point**
+: The point in the Main Canvas where an action such as Paste takes place.
+This can be the Mouse, the Playhead or a Marker.
+
+**Editor Window**
+: Ardour provides two ways of viewing a session: the Editor and the Mixer.
+The Editor represents the time based aspects of a session: it shows
+tracks and busses as horizontal timeline displays, with material within
+the tracks (audio, MIDI, video, automation data, etc.) arranged along
+the horizontal (time) axis.
+
+**EQ**
+: See Equalization.
+
+**Equalization**
+: Equalization (EQ) is the process of adjusting the relative levels of
+different frequencies in a recording or signal. In other words, it is
+the process of boosting or attenuating the various frequency bands of a
+sound according to a chosen artistic goal.
+
+**Filter**
+: A type of signal processing that supresses some frequencies. 
+
+**Floating Point Numbers**
+: It is simply a number with a decimal point. "Floating Point" refers to
+the specific technique the computer uses to represent a larger range of
+integer and non-integer values.
+
+**FLAC**
+: An open source lossless audio format generally compatible with Linux,
+Windows and Macintosh. Unlike AIFF and WAV, FLAC is a compressed format,
+allowing file sizes to be reduced. 
+
+**FLOSS**
+: FLOSS stands for Free Libre Open Source Software. FLOSS Manuals is a
+collection of manuals about free and open source software together with
+the tools used to create them and the community that uses those tools.
+They include authors, editors, artists, software developers, activists,
+and many others.
+
+**Format** (audio file)
+: The types of sound file that sounds are saved as. Among the most common
+are AIFF, WAV, FLAC, mp3 and Ogg Vorbis. 
+
+**fps**
+: Frames Per Second. Frame rate, or frame frequency is the frequency
+(rate) at which an imaging device produces unique consecutive images
+called frames. The term applies equally well to computer graphics, video
+cameras, film cameras, and motion capture systems. Frame rate is most
+often expressed in frames per second (FPS). 
+
+**Frequency**
+: Refers to the number of times an oscillation occurs in one second.
+Frequency is measured in **Hertz**, and is correlated to the **pitch**
+of a sound. Frequency is a **linear** scale, while pitch is
+**logarithmic**. The pitch 'A' above the middle C has a frequency of 440
+Hz. The 'A' one octave above is twice that frequency (880 Hz).
+
+**Gain**
+: Increasing the **level**of an audio signal, usually measured using a
+**logarithmic** scale. See also **attenuation**.
+
+**Grid**
+: The Grid is a system of points that a Region might snap to while editing
+it. The Grid can be "No Grid", "Grid" or "Magnetic". 
+
+**Grid Points**
+: The points in the **Grid** which Regions will snap to when it is active.
+Grid Points may be minutes, seconds, video frames, bars, beats or some
+multiple of beats. 
+
+**Hertz**
+: A term used to describe the number of times something occurs in one
+second. In digital audio, it is used to describe the **sampling rate**,
+and in acoustics it is used to describe the **frequency** of a sound.
+Thousands of Herz are described as kHz (kilo Herz). 
+
+**High Shelf**
+: In an **Equalizer**, a **Shelf** cuts or boosts everything above (High
+Shelf) or below (Low Shelf) a specific frequency.
+
+**Headroom**
+: The range of **Decibels** between the region's maximum **Peak**and the
+**Clipping Point** is commonly referred to as **Headroom**. It is common
+recording practice to keep approximately three to six Decibels of
+Headroom between the maximum of your signal and the Clipping Point.
+
+**Jack Audio Connection Kit (JACK)**
+: JACK is a low-latency audio system which manages connections between
+Ardour and the soundcard of your computer, and between Ardour and other
+JACK-enabled audio programs on your computer. You must install JACK for
+Linux or JackOSX before you can use Ardour.
+
+**JackOSX** (OS X)
+: The name of the version of **JACK** that runs on macOS. See **JACK**
+for more details. 
+
+**JackPilot**
+: The control interface that comes with JackOSX. 
+
+**Jack Server**
+: The Jack Server is the "engine" or "backend" of the Jack Audio
+Connection Kit. 
+
+**Jack Router**
+: The Jack Router allows audio to be routed from one application to
+another using the **Jack Server**. 
+
+**JAMin**
+: JAMin is the Jack Audio Connection Kit Audio Mastering interface. JAMin
+is an open source application designed to perform professional audio
+mastering of stereo input streams. It uses **LADSPA** for digital signal
+processing (DSP).
+
+**LADSPA Plugins**
+: Linux Audio Developer Simple Plugin API (LADSPA) is a standard that
+allows software audio processors and effects to be plugged into a wide
+range of audio synthesis and recording packages. For instance, it allows
+a developer to write a reverb program and bundle it into a LADSPA
+"plugin library." Ordinary users can then use this reverb within any
+LADSPA-friendly audio application. Most major audio applications on
+Linux support LADSPA.
+
+**Latency**
+: Latency is the amount of time needed to process all the samples coming
+from sound applications on your computer and send it to the soundcard
+for playback, or to gather samples from the sound card for recording or
+processing. A shorter latency means you will hear the results quicker,
+giving the impression of a more responsive system. However, with a
+shorter latency you also run a greater risk of **glitches** in the audio
+because the computer might not have enough time to process the sound
+before sending it to the soundcard. A longer latency means fewer
+glitches, but at the price of a slower response time. Latency is
+measured in milliseconds.
+
+**Limiting**
+: The process by which the amplitude of the output of a device is
+prevented from exceeding a predetermined value.
+
+**Linear**
+: A scale of numbers which progresses in an additive fashion, such as by
+adding one (1, 2, 3, 4...), two (2, 4, 6, 8...) or ten (10, 20, 30,
+40...). Multiplying an audio signal, for example, by either a linear or
+a logarithmic scale will produce very different results. The scale of
+**frequency** is linear, while the scales of **pitch** and **gain** are
+logarithmic.
+
+**Linux kernel**
+: The core of the GNU/Linux operating system. In a **Real-time System**,
+this kernel is usually **Compiled**with new parameters which speed up
+the use of audio applications in the system. 
+
+**Lock Edit**
+: One of the three available **Edit Modes**, Lock Edit is similar to
+**Slice Edit**, but regions will remain at their original positions
+regardless of any edit operation performed.
+
+**Logarithmic**
+: A scale of numbers which progresses according to a certain ratio, such
+as exponentially (2, 4, 8, 16, 256...). Both scales of **pitch** and
+**gain** are logarithmic, while the scale of **frequency** is linear.
+
+**Lossless**
+: See **Compression** (data) 
+
+**Lossy**
+: See Compression (data)
+
+**Loudness**
+: Unlike **amplitude**, which expresses the physical power of a sound,
+loudness is the perceived strength of a sound. Tones at different
+frequencies may be perceived as being at different loudnesses, even if
+they are at the same amplitude.
+
+**LV2** 
+: LV2 is an open standard for plugins and matching host applications,
+mainly targeted at audio processing and generation. LV2 is a simple but
+extensible successor of LADSPA, intended to address the limitations of
+LADSPA which many applications have outgrown.
+
+**Main Canvas**
+: In the Editor Window of Ardour, the Main Canvas is the space just below
+the timeline rulers where Tracks and Busses are displayed horizontally.
+
+**Master Out**
+: A master out is a bus to which all (or most) tracks and other busses
+send their output. It provides a convenient single point of control for
+the output of Ardour, and is a typical location for global effects.
+Master out use is enabled by default, and the master out bus is set up
+to be stereo.
+
+**Meter**
+: The grouping of strong and weak beats into larger units called bars or
+measures. 
+
+**Mixing**
+: Audio mixing is the process by which a multitude of recorded sounds are
+combined into one or more channels, most commonly two-channel stereo. In
+the process, the levels, frequency content, dynamics and panoramic
+position of the source signals are commonly manipulated and effects such
+as reverb may be added. 
+
+**MIDI**
+: MIDI is an industry-standard protocol defined
+in^[](http://en.wikipedia.org/wiki/Musical_Instrument_Digital_Interface#cite_note-0)^
+1982 that enables electronic musical instruments such as keyboard
+controllers, computers and other electronic equipment to communicate,
+control, and synchronize with each other. MIDI allows computers,
+synthesizers, MIDI controllers, sound cards, samplers and drum machines
+to control one another, and to exchange system data. MIDI does not
+transmit audio signals, but simply messages such as note number (pitch),
+velocity (intensity), note-on, and note-off.
+
+**Mixer Strip**
+: Each track and bus is represented in the Mixer Window by a vertical
+Mixer Strip** that contains various controls related to signal flow.
+There are two places in Ardour in which you can see mixer strips. The
+mixer window is the obvious one, but you can also view a single mixer
+strip on the left hand side of the Editor (shift + E to hide/view) 
+
+**Mixer Window**
+: The Mixer shows the session by representing tracks vertically as Mixer
+Strips, with controls for gain, record enable, soloing, plugins etc. The
+Mixer represents the signal flow of Tracks and Busses in an Ardour
+session. The mixer window provides a view that mimics a traditional
+hardware mixing console.
+
+**Monitoring**
+: Monitoring is the process of routing a specific mix or submix of your
+session into separate outputs (like headphones). For example, a musician
+being recorded may want to listen to existing material while performing.
+Ardour and JACK make it easy to setup monitor outs since any incoming
+signal can then be delivered back to any output, optionally mixed
+together with other signals and with any kind of sound processing added.
+
+**Mono**
+: A mono sound file contains only one channel of audio. A mono track in
+Ardour has only one input and handles mono sound files. 
+
+**MP3**
+: A lossy, size-compressed sound file **Format**. 
+
+**Graphic Equalizer/Multi-Band Equalizer**
+: A Graphic (or Multi-Band) Equalizer consists of a bank of sliders for
+boosting or attenuating different frequency of a sound. 
+
+**Non-destructive Editing/Recording**
+: This is a form of editing where the original content is not modified in
+the course of editing. Behind the scenes, the original sound file is
+kept intact, and your edits are in fact a list of instructions that
+Ardour will use in order to reconstruct the signal from the original
+source when you play it back. For example, creating fade-ins and
+fade-outs on your Regions is a type of non-destructive editing. 
+
+**Normalize**
+: To normalize an audio signal means to adjust its **Gain** so that it
+peaks at the maximum the sound card allows before **Clipping**.
+
+**Normal Mode**
+: See **Track Mode**. 
+
+**Note value**
+: The proportional duration of a note or rest in relation to a standard
+unit. For instance, a 'quarter note' (crotchet) is so-called because its
+relative duration is one quarter of a whole note (semibreve). 
+
+**Octave** (music) 
+: A distance of 12 semitones between two notes. In **Hertz**, the ratio of
+an octave is 2:1. For example, the note 'A' above the middle C has a
+frequency of 440 Hz. The note 'A' one octave above is 880 Hz, and one
+octave below is 220 Hz. 
+
+**Ogg Vorbis**
+: An open source lossy, size-compressed sound file format. 
+
+**Panning**
+: Panning is the location of sounds in the **Stereo Field**. 
+
+**Parametric Equalizer**
+: The Parametric Equalizer is the most versatile type of**EQ** used for
+**Mixing** because of its extensive control over all the parameters of
+filtering. 
+
+**Peaks**
+: Peaks are a graphical representation of the maximum **Levels** of a
+**Region**. 
+
+**Peak Meters**
+: Peak Meters are a running representation of the maximum Levels of a
+Region, and are located next to the Fader in the Mixer Window, and also
+in the Track Mixer, of each Track. 
+
+**Pitch**
+: Pitch represents the perceived fundamental frequency of a
+sound.^[](http://en.wikipedia.org/wiki/Pitch_(music)#cite_note-0)^^^It
+is one of the three major auditory attributes of sounds along with
+loudness and timbre. In MIDI, pitch is represented by a number between 0
+and 127, with each number representing a key on a MIDI keyboard. The
+relation of pitch to **Frequency** is **Logarithmic**. This means that a
+sound which is heard as one **Octave**(+12 MIDI notes) above another one
+is twice the frequency in Hz, while a sound one octave below (-12 MIDI
+notes) is half the frequency.
+
+**Playhead**
+: In Ardour, the Playhead is the red line that moves in time (i.e., left
+to right) to indicate the current playback position. 
+
+**Plugin**
+: In computing, a plugin consists of a computer program that interacts
+with a host application (in this case, Ardour) to provide a certain
+function "on demand", usually a very specific one. Reverb, filters, and
+equalizers are examples of plugins that can be used in Ardour in
+association with Tracks or Busses.
+
+**Portaudio**
+: A free and open source set of **audio drivers**for Linux and macOS.
+
+**Post-Fader** (Plugin or Send)
+: In the Mixer Strip, the post-fader area is the black space below the
+gain slider, to which plugins or sends can be added. The input of these
+plugins and sends will be the signal *after* any manual or automated
+gain change (thus "post-fader"). 
+
+**Pre-Fader** (Plugin or Send)
+: In the Mixer Strip, the pre-fader area is the black space above the gain
+slider, to which plugins or sends can be added. The input of these
+plugins and sends will be the incoming signal *before* it is affected by
+any manual or automated gain changes controlled by the slider (thus
+"pre-fader").
+
+**Quantization**
+: In signal processing, quantization may refer to bit depth (see **bit
+depth** definition). In MIDI, quantization refers to the process of
+aligning notes to a precise temporal grid. This results in notes being
+set on beats or exact fractions of beats. MIDI sequencers typically
+include some type of quantization function.
+
+**Range**
+: A segment of time. Ranges are created with the Select/Move Ranges tool
+and may include one or more tracks. Loop and punch ranges are special
+types of ranges that are created and manipulated with the loop/punch
+ranges meter.
+
+**Real-time System**(Linux)
+: In a **Real-time System**, the **Linux kernel** is usually recompiled
+(rebuilt) with new parameters, and other settings in the system are
+optimized which speed up the use of audio applications in the system.
+
+**Regions**
+: Regions are the basic elements of editing and composing in Ardour. Each
+region represents all or part of an audio file. Removing a region from a
+track does not remove the audio file from the disk.
+
+**Region List**
+: The region list is located at the right hand side of the Editor Window
+and it shows all the regions associated with the session. 
+
+**Reverberation**
+: Reverberation is the persistence of sound in a particular space after
+the original sound source is
+removed.^[](http://en.wikipedia.org/wiki/Reverberation#cite_note-0)^^^A
+reverberation, or reverb, is created when a sound is produced in an
+enclosed space causing a large number of echoes to build up and then
+slowly decay as the sound is absorbed by the walls and air. Digital
+reverberation can be added to a sound in Ardour through the use of
+plugins. 
+
+**Right Click** (mouse)
+: Click on the right button of your mouse.
+
+**Routing**
+: Routing is sending an audio signal from somewhere to somewhere else.
+Signals can be routed not only from the outside world into Ardour and
+vice-versa, but also within Ardour itself (for example, from a Track to
+a Bus).
+
+**Rulers**
+: Rulers are the thin horizontal bars that display the time line, helping
+to see when exactly a region or sound starts or stops. Also displayed
+with the rulers are the meter and tempo markers, the location markers,
+the range markers and the loop/punch ranges. 
+
+**Sample** (data)
+: In digital audio, a sample is the smallest possible segment of a
+recorded sound. In CD audio, for example, it takes 44,100 samples to
+make one second of recorded sound, and so we can say that the **sampling
+rate** is 44,100 **Hertz**. Samples also have a **bit depth** which
+determines the **dynamic range** that is possible to record and
+playback. Common bit depths are 16 (for CD audio), 24 (for studio
+recording and DVDs) or 32 (for sounds inside the computer).
+
+**Sample** (music) 
+: In electronic music, the word sample can mean any portion of sound
+extracted from an existing piece of music to be reused in a new
+composition.
+
+**Sampler**
+: An electronic music instrument or software which plays back a recorded
+sound (or **sample**) whenever it is sent a **note** message. The
+**pitch** of the note determines how fast or slow the sample is played
+back, which emulates the pitch changes in other instruments. Samples can
+be looped (played over and over) and one-shot (played once).
+
+**Sampling Rate**
+: The rate at which the computer records and plays back sound, which is
+measured in **Hertz**representing the number of **samples**per second.
+CD audio is recorded and played at 44,100 Hz (or 44.1 kHz), while DVD
+audio runs at 96,000 Hz (96 kHz) and cheap consumer gadgets like voice
+recorders, video games, mobile phones, toys and some MP3 players often
+use a rate of 22,050 Hz (22.05 kHz) or even less. The sampling rate
+determines the highest **frequency** that can be recorded or played,
+which is expressed by the Nyquist number (half the sampling rate).
+Playing back sounds at a different sampling rate then they were recorded
+at will result in hearing that sound at the "wrong speed".
+
+**Send**
+: An optional auxiliary output for a track or bus.
+
+**Session**
+: A session is all of the information that constitutes one project in
+Ardour. Each session is saved in its own folder containing all the
+audio, region and parametric data, and a master file with the .ardour
+extension.
+
+**Shelf**
+: In an **Equalizer**, a **Shelf** cuts or boosts everything above (High
+Shelf) or below (Low Shelf) a specific frequency.
+
+**Slice Edit**
+: One of the three available **Edit Modes**, Slice Edit does not allow
+dragging regions around, but still allows you to perform slice
+operations (such as cut, paste, and split). Space between regions will
+be kept constant after any edit operation that affects it. If you delete
+the second half of a region, for example, any subsequent regions on the
+same track will automatically move back in the time grid.
+
+**Slide Edit**
+: Another one of the three available **Edit Modes**, Slide Edit is the
+default mode. It allows you to drag regions around horizontally (within
+the same track) and vertically (between tracks).
+
+**SMPTE timecode**
+: : A set of cooperating standards to label individual frames of video
+or film with a timecode defined by the Society of Motion Picture and
+Television Engineers. Timecodes are added to film, video or audio
+material, and have also been adapted to synchronize music. They provide
+a time reference for editing, synchronization and identification.
+
+**Snap Mode**
+: The **Snap Mode** menus are found just below the **Clocks**. They
+control the amount **Quantization** of the time grid, i.e., the amount
+of "snap" an audio **Region** has to the type of grid you have chosen.
+
+**Snapshots**
+: Saving a snapshot in Ardour is similar to saving the session to a new
+file to avoid overwriting the original session file. A snapshot contains
+the current state of your work, while sharing all the audio and data
+files of the Session. If you were trying to find a "Save As" function in
+Ardour, saving a snapshot is probably what you are looking for. 
+
+**Solo**
+: Toggle switch found in track controls and mixer strips. When toggled on,
+only solo tracks will send output. Several tracks can be marked solo at
+once. The general Solo button (top row of controls in the Editor Window)
+can be used to un-solo all soloed tracks at once.
+
+**Spectrum**
+: The representation of a signal in terms of its frequency components. 
+
+**Stereo**
+: A stereo sound file contains two channels of audio (usually known as
+Left and Right channels). A stereo track in Ardour has two inputs and
+outputs, in order to record and playback stereo files.
+
+**Stereo Field**
+: Stereo field is the perception of spatial location of sounds based on a
+sound reproduction system of 2 channels (Left and Right). 
+
+**Take**(recording)
+: A sequence of sound recorded continuously at one time.
+
+**Tape Mode**
+: See **Track Mode**. 
+
+**Tempo**(music)
+: The rate at which beats occur. Precise Tempo indications are measured in
+**bpm** (beats per minute), although subjective indications are also
+common in scores (Allegro, Adagio, Very Fast, etc). 
+
+**Terminal**
+: A "terminal" is the text-based interface that allows to operate a
+computer by typing commands into it. Most computer users today rely
+solely on a graphical interface to control their systems. Both macOS
+and Linux though, include a terminal which may make some tasks easier
+for some users. 
+
+**Timecode**
+: A time code is a sequence of numeric codes generated at regular
+intervals by a timing system. The SMPTE family of timecodes is almost
+universally used in film, video and audio production.
+
+**Time Signature** (music) 
+: A sign placed at the start of a piece of music (after the clef and key
+signature) or during the course of it, indicating the meter of the
+music.
+
+**Track**
+: A Track is the place to where you can drag a **Region** from your
+**Region List**and where you can record sounds coming from an
+outside source. The Mixer Strip vertically represents the signal flow of
+a track, whereas the Main Canvas horizontally displays time-based
+information for each track. 
+
+**Track Mode**
+: **Track Mode** gives you a choice between **Normal Mode** and **Tape
+Mode**. Normal Mode creates a new Region for each Recording **Take**,
+while **Tape Mode** destructively records--in other words the previous
+Take of a Track is eliminated with each new Take.
+
+**Transport**
+: The buttons located on the upper left corner of the Editor Window, with
+controls such as Rewind, Play, Stop. 
+
+**Treble**(frequencies)
+: Generic way of referring to high frequencies of the **Spectrum** of a
+sound.
+
+**VST (Virtual Studio Technology)**
+: [Steinberg](http://en.wikipedia.org/wiki/Steinberg) VST is an
+interface for integrating software audio synthesizer and effect plugins
+with audio editors and digital workstations such as Ardour. VST and
+similar technologies use digital signal processing to simulate
+traditional recording studio hardware with software. Thousands of
+plugins exist, both commercial and freeware. VST was created by
+Steinberg. 
+
+**WAV**
+: A sound file format developed by Microsoft and IBM and commonly used for
+lossless and uncompressed audio. WAV files are compatible with Windows,
+Macintosh and Linux operating systems.
+
+**Waveform**
+: The time-domain visual representation of a sound. Waveforms are drawn
+inside the colored rectangles representing Regions in the Main Canvas.
+
+**Word length**
+: See **Bit Depth**. 

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -72,63 +72,35 @@ Les signaux audio ayant une amplitude plus élevée ont généralement un son pl
 : Un bit (**bi**nary dig**it**) est un nombre unique dont la valeur est soit 0 soit 1. 
 
 **Bit Depth**
-: Refers to the number of bits used to write a _sample_. In the CD
-standard, each sample of audio is represented by a 16-bit number. This
-gives 2\^16 (two to the power of sixteen = 65,536) possible values that
-a sample can have. A higher bit depth means a greater possible _dynamic
-range_. Studio recordings are usually first made recorded with a bit
-depth of 24 (or even 32) to preserve as much detail before transfer to
-CD. DVDs are made at 24 bit, while video games from the 1980s remain
-famous for their distinctively rough "8 bit sound". Bit depth is also
-referred to as **word length**. 
+: Se réfère au nombre de bits utilisés pour écrire un _échantillon_. Dans la norme CD, chaque échantillon audio est représenté par un nombre de 16 bits. Cela donne 2\^16 (deux à la puissance seize = 65 536) valeurs possibles qu'un échantillon peut avoir. Une plus grande profondeur de bits signifie une plus grande _plage dynamique_ possible. Les enregistrements en studio sont généralement réalisés avec une profondeur de bits de 24 (voire 32) pour préserver le plus de détails possible avant le transfert sur CD. Les DVD sont réalisés en 24 bits, tandis que les jeux vidéo des années 1980 sont restés célèbres pour leur "son 8 bits" distinctif et rugueux. La profondeur de bits est également également appelée **word length**. 
 
 **Buffer Size** (JACK)
-: The buffer is a section of memory specifically allotted to temporary
-signal data. Small buffer sizes allow a lower latency and so are needed
-when using audio applications that require real-time interaction. The
-drawback is that CPU consumption for the system is higher with smaller
-buffer sizes. Larger buffers (like 512 or 1024) can be used when there
-is no such requirement.
+: La mémoire tampon est une section de la mémoire spécifiquement allouée aux données temporaires du signal.
+Les petites tailles de mémoire tampon permettent une latence plus faible et sont donc nécessaires pour les applications audio qui nécessitent une interaction en temps réel.
+lors de l'utilisation d'applications audio nécessitant une interaction en temps réel. L'inconvénient est que la consommation de CPU pour le système est plus élevée avec des petites tailles de mémoire tampon. Des tampons plus grands (comme 512 ou 1024) peuvent être utilisés lorsqu'il n'y a pas de telles exigences.
 
 **Built-in Input and Output**
-: These are the default interfaces for getting sound in and out of your
-computer if you don't have an external sound card. In a laptop, they are
-the common input (mic) and output (headphone) connections.
+: Ce sont les interfaces par défaut pour faire entrer et sortir le son de votre ordinateur si vous n'avez pas de carte son externe.
+Dans un ordinateur portable, il s'agit des connexions communes d'entrée (micro) et de sortie (casque).
 
 **Bus**
-: A bus is similar to a track except that it does not contain its
-own regions. You cannot record directly into a bus or drag regions into
-it. The _Mixer_ strip vertically represents the signal flow of a bus,
-whereas the Main Canvas horizontally displays time-based information for
-each bus (such as automation lines).
+: Un bus est similaire à une piste, sauf qu'il ne contient pas ses propres régions. Vous ne pouvez pas enregistrer directement dans un bus ni y faire glisser des régions. La bande _Mixer_ représente verticalement le flux de signal d'un bus, tandis que le canevas principal affiche horizontalement des informations temporelles pour chaque bus (telles que les lignes d'automatisation).
 
 **BWF**
-: Broadcast Wave Format (BWF) is an extension of the popular Microsoft
-WAVE audio format and is the recording format of most file-based
-non-linear digital recorders used for motion picture and television
-production. This file format allows the inclusion of metadata to
-facilitate the seamless exchange of sound data between different
-computer platforms and applications.
+: Broadcast Wave Format (BWF) est une extension du célèbre format audio Microsoft WAVE et est le format d'enregistrement de la plupart des enregistreurs numériques non linéaires utilisés pour la production cinématographique et télévisuelle.
+Ce format de fichier permet d'inclure des métadonnées pour faciliter l'échange de données sonores entre différentes plates-formes et applications informatiques.
 
 **CAF**
-: CAF (Core Audio Format) is a file format for storing audio, developed by
-Apple. It is compatible with macOS 10.4 and higher. The Core Audio
-Format is designed to overcome limitations of older digital audio
-formats, including AIFF and WAV. Just like the QuickTime .mov file
-format, a .caf file format can contain many different audio formats,
-metadata tracks, and much more data.
+: CAF (Core Audio Format) est un format de fichier pour le stockage de données audio, développé par Apple.
+Il est compatible avec macOS 10.4 et les versions ultérieures. Le format Core Audio est conçu pour surmonter les limites des anciens formats audio numériques, notamment AIFF et WAV. Tout comme le format de fichier QuickTime .mov, un format de fichier .caf peut contenir de nombreux formats audio différents, des pistes de métadonnées et bien d'autres données.
 
 **Center Frequency**
-: In some EQ plugins, the user has the possibility of choosing the center
-frequency for each of the frequency bands. The center frequency of a
-Band will be the one most sharply attenuated or reinforced by the
-equalizer for that specific band. Frequencies surrounding the center
-frequency will be less affected. 
+: Dans certains greffons d'égalisation, l'utilisateur a la possibilité de choisir la fréquence centrale pour chaque bande de fréquence.
+La fréquence centrale d'une bande sera celle qui sera la plus fortement atténuée ou renforcée par l'égaliseur pour cette bande spécifique. Les fréquences l'entourant seront moins affectées.
 
 **Click** (Mouse)
-: In this manual, it specifically means to click on the left button of
-your mouse. Whenever the right button is required, the action is
-referred to as "right-click".
+: Dans ce manuel, il s'agit de cliquer sur le bouton gauche de la souris.
+Lorsque le bouton droit est requis, l'action est appelée "clic droit".
 
 **Clipping**
 : Clipping occurs when a signal is too high in level to be reproduced. Any

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -157,61 +157,44 @@ sont disponibles sous forme de fichiers .dmg.
 : Digital Signal Processing.
 
 **Dynamic Range**
-: Used to refer to the difference between the loudest and the quietest
-sound that can possibly recorded, as well as the amount of detail which
-can be heard in between those extremes. Sounds which are too quiet to be
-recorded are said to be below the **noise floor**of the recording system
-(microphone, recorder, sound card, audio software, etc). Sounds which
-are too loud will be **distorted**or **clipped**. 
+: Utilisé pour faire référence à la différence entre le son le plus fort et le son le plus faible qu'il est possible d'enregistrer, ainsi qu'à la quantité de détails qui peuvent être entendus entre ces deux extrêmes. Les sons qui sont trop faibles pour être
+être enregistrés sont considérés comme étant en dessous du **plancher de bruit** du système d'enregistrement (microphone, enregistreur, carte son, etc.). Les sons qui
+sont trop forts seront **distordus** ou **écrêtés**. 
 
 **Edit** **Modes**
-: The three available Edit Modes (**Slide Edit**, **Slice Edit**, and
-**Lock Edit**) control the behavior of editing operations in the **Main
-Canvas**.
+: Les trois modes d'édition disponibles (**Slide Edit**, **Slice Edit** et **Lock Edit**) contrôlent le comportement des opérations d'édition dans le **Main Canvas**.
 
 **Edit Point**
-: The point in the Main Canvas where an action such as Paste takes place.
-This can be the Mouse, the Playhead or a Marker.
+: Point du canevas principal où se déroule une action telle que Coller. Il peut s'agir de la souris, de la tête de lecture ou d'un marqueur.
 
 **Editor Window**
-: Ardour provides two ways of viewing a session: the Editor and the Mixer.
-The Editor represents the time based aspects of a session: it shows
-tracks and busses as horizontal timeline displays, with material within
-the tracks (audio, MIDI, video, automation data, etc.) arranged along
-the horizontal (time) axis.
+: Ardour propose deux façons de visualiser une session : l'éditeur et le mixeur.
+L'éditeur représente les aspects temporels d'une session :
+Il affiche les pistes et les bus comme des affichages horizontaux, avec le matériel dans les pistes (audio, MIDI, vidéo, données d'automatisation, etc.) le long de l'axe horizontal (temps).
 
 **EQ**
-: See Equalization.
+: Voir Égalisation.
 
-**Equalization**
-: Equalization (EQ) is the process of adjusting the relative levels of
-different frequencies in a recording or signal. In other words, it is
-the process of boosting or attenuating the various frequency bands of a
-sound according to a chosen artistic goal.
+**Égalisation**
+: L'égalisation (EQ) est le processus d'ajustement des niveaux relatifs des différentes fréquences dans un enregistrement ou un signal.
+En d'autres termes, c'est le processus d'augmentation ou d'atténuation des différentes bandes de fréquences d'un son en fonction d'un objectif artistique choisi.
 
 **Filter**
-: A type of signal processing that supresses some frequencies. 
+: Un type de traitement du signal qui supprime certaines fréquences. 
 
 **Floating Point Numbers**
-: It is simply a number with a decimal point. "Floating Point" refers to
-the specific technique the computer uses to represent a larger range of
-integer and non-integer values.
+: Il s'agit simplement d'un nombre avec un point décimal. Le terme "virgule flottante" fait référence à la technique spécifique utilisée par l'ordinateur pour représenter une gamme plus large de valeurs entières et non entières.
 
 **FLAC**
-: An open source lossless audio format generally compatible with Linux,
-Windows and Macintosh. Unlike AIFF and WAV, FLAC is a compressed format,
-allowing file sizes to be reduced. 
+: Format audio sans perte à source ouverte généralement compatible avec Linux, Windows et Macintosh. Contrairement à AIFF et WAV, FLAC est un format compressé, permettant de réduire la taille des fichiers.
 
 **FLOSS**
-: FLOSS stands for Free Libre Open Source Software. FLOSS Manuals is a
-collection of manuals about free and open source software together with
-the tools used to create them and the community that uses those tools.
-They include authors, editors, artists, software developers, activists,
-and many others.
+: FLOSS est l'acronyme de Free Libre Open Source Software. FLOSS Manuals est une collection de manuels sur les logiciels libres et open source, ainsi que sur les outils utilisés pour les créer et la communauté qui utilise ces outils.
+Ils comprennent des auteurs, des éditeurs, des artistes, des développeurs de logiciels, des activistes, et bien d'autres.
 
 **Format** (audio file)
-: The types of sound file that sounds are saved as. Among the most common
-are AIFF, WAV, FLAC, mp3 and Ogg Vorbis. 
+: Les types de fichiers sonores sous lesquels les sons sont enregistrés. Parmi les plus courants
+on trouve AIFF, WAV, FLAC, mp3 et Ogg Vorbis. 
 
 **fps**
 : Frames Per Second. Frame rate, or frame frequency is the frequency

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -519,86 +519,50 @@ slowly decay as the sound is absorbed by the walls and air. Digital
 reverberation can be added to a sound in Ardour through the use of
 plugins. 
 
-**Right Click** (mouse)
-: Click on the right button of your mouse.
+**Right Click** (souris)
+: Cliquez sur le bouton droit de la souris.
 
 **Routing**
-: Routing is sending an audio signal from somewhere to somewhere else.
-Signals can be routed not only from the outside world into Ardour and
-vice-versa, but also within Ardour itself (for example, from a Track to
-a Bus).
+: Le routage consiste à envoyer un signal audio d'un endroit à un autre.
+Les signaux peuvent être routés non seulement du monde extérieur vers Ardour et vice-versa, mais aussi à l'intérieur même d'Ardour (par exemple, d'une piste vers un bus).
 
 **Rulers**
-: Rulers are the thin horizontal bars that display the time line, helping
-to see when exactly a region or sound starts or stops. Also displayed
-with the rulers are the meter and tempo markers, the location markers,
-the range markers and the loop/punch ranges. 
+: Les règles sont les fines barres horizontales qui affichent la ligne temporelle, ce qui aide à voir quand une région ou un son commence ou il s'arrête exactement. Les marqueurs de mesure et de tempo, les marqueurs d'emplacement, les marqueurs d'intervalles et les intervalles de boucles et de punch sont eux aussi affichés avec les règles.
 
-**Sample** (data)
-: In digital audio, a sample is the smallest possible segment of a
-recorded sound. In CD audio, for example, it takes 44,100 samples to
-make one second of recorded sound, and so we can say that the **sampling
-rate** is 44,100 **Hertz**. Samples also have a **bit depth** which
-determines the **dynamic range** that is possible to record and
-playback. Common bit depths are 16 (for CD audio), 24 (for studio
-recording and DVDs) or 32 (for sounds inside the computer).
+**Sample** (données)
+: En audio numérique, un échantillon est le plus petit segment possible d'un son enregistré.
+En audio CD, par exemple, il faut 44 100 échantillons pour obtenir une seconde de son enregistré et nous pouvons donc dire que le **taux d'échantillonnage** est de 44 100 **Hertz**.
+Les échantillons ont également une **profondeur de bits** qui détermine la **plage dynamique** qu'il est possible d'enregistrer et de d'enregistrement et de lire. Les profondeurs de bits courantes sont de 16 (pour les CD audio), 24 (pour les enregistrements en studio et les DVD) ou 32 (pour les sons à l'intérieur de l'ordinateur).
 
-**Sample** (music) 
-: In electronic music, the word sample can mean any portion of sound
-extracted from an existing piece of music to be reused in a new
-composition.
+**Sample** (musique) 
+: Dans le domaine de la musique électronique, le mot "sample" peut désigner toute portion de son extrait d'un morceau de musique existant pour être réutilisé dans une nouvelle composition.
 
 **Sampler**
-: An electronic music instrument or software which plays back a recorded
-sound (or **sample**) whenever it is sent a **note** message. The
-**pitch** of the note determines how fast or slow the sample is played
-back, which emulates the pitch changes in other instruments. Samples can
-be looped (played over and over) and one-shot (played once).
+: Un instrument de musique électronique ou un logiciel qui lit des sons enregistrés (ou **sample**) chaque fois qu'un message **note** lui est envoyé. La **hauteur** de la note détermine la vitesse ou la lenteur avec laquelle l'échantillon est joué, ce qui émule les changements de hauteur dans d'autres instruments. Les échantillons peuvent être joués en boucle (à plusieurs reprises) ou en une seule fois.
 
 **Sampling Rate**
-: The rate at which the computer records and plays back sound, which is
-measured in **Hertz**representing the number of **samples**per second.
-CD audio is recorded and played at 44,100 Hz (or 44.1 kHz), while DVD
-audio runs at 96,000 Hz (96 kHz) and cheap consumer gadgets like voice
-recorders, video games, mobile phones, toys and some MP3 players often
-use a rate of 22,050 Hz (22.05 kHz) or even less. The sampling rate
-determines the highest **frequency** that can be recorded or played,
-which is expressed by the Nyquist number (half the sampling rate).
-Playing back sounds at a different sampling rate then they were recorded
-at will result in hearing that sound at the "wrong speed".
+: La vitesse à laquelle l'ordinateur enregistre et lit le son, mesurée en **Hertz** représentant le nombre d'**échantillons** par seconde.
+Les CD audio sont enregistrés et lus à 44 100 Hz (ou 44,1 kHz), tandis que les DVD audio fonctionnent à 96 000 Hz (96 kHz) et les gadgets grand public bon marché comme les enregistreurs vocaux, les jeux vidéo, les téléphones portables, les jouets et certains lecteurs MP3 utilisent souvent une fréquence de 22 050 Hz, voire moins. La fréquence d'échantillonnage détermine la **fréquence** la plus élevée qui peut être enregistrée ou jouée, qui est exprimée par le nombre de Nyquist (la moitié de la fréquence d'échantillonnage).
+La lecture de sons à une fréquence d'échantillonnage différente de celle à laquelle ils ont été enregistrés entraînera leur lecture à la mauvaise vitesse.
 
 **Send**
-: An optional auxiliary output for a track or bus.
+: Une sortie auxiliaire optionnelle pour une piste ou un bus.
 
 **Session**
-: A session is all of the information that constitutes one project in
-Ardour. Each session is saved in its own folder containing all the
-audio, region and parametric data, and a master file with the .ardour
-extension.
+: Une session est l'ensemble des informations qui constituent un projet dans Ardour.
+Chaque session est sauvegardée dans son propre dossier contenant toutes les données audio, régionales et paramétriques, ainsi qu'un fichier maître portant l'extension .ardour.
 
 **Shelf**
-: In an **Equalizer**, a **Shelf** cuts or boosts everything above (High
-Shelf) or below (Low Shelf) a specific frequency.
+: Dans un **Equalizer**, une **Shelf** coupe ou renforce tout ce qui se trouve au-dessus (High Shelf) ou au-dessous (Low Shelf) d'une fréquence spécifique.
 
 **Slice Edit**
-: One of the three available **Edit Modes**, Slice Edit does not allow
-dragging regions around, but still allows you to perform slice
-operations (such as cut, paste, and split). Space between regions will
-be kept constant after any edit operation that affects it. If you delete
-the second half of a region, for example, any subsequent regions on the
-same track will automatically move back in the time grid.
+: L'un des trois **modes d'édition** disponibles, l'édition en tranches ne permet pas de faire glisser des régions, mais permet néanmoins d'effectuer des opérations de coupes (telles que couper, coller et diviser). L'espace entre les régions sera maintenu constant après toute opération d'édition qui l'affecte. Si vous supprimez la seconde moitié d'une région, par exemple, toutes les régions suivantes sur la même piste reculeront automatiquement dans la grille temporelle.
 
 **Slide Edit**
-: Another one of the three available **Edit Modes**, Slide Edit is the
-default mode. It allows you to drag regions around horizontally (within
-the same track) and vertically (between tracks).
+: Un autre des trois **modes d'édition** disponibles, l'édition des diapositives est le mode par défaut. Il vous permet de faire glisser des régions horizontalement (au sein de la même piste) et verticalement (entre les pistes).
 
 **SMPTE timecode**
-: : A set of cooperating standards to label individual frames of video
-or film with a timecode defined by the Society of Motion Picture and
-Television Engineers. Timecodes are added to film, video or audio
-material, and have also been adapted to synchronize music. They provide
-a time reference for editing, synchronization and identification.
+: Ensemble de normes coopératives permettant d'étiqueter les images individuelles d'une vidéo ou d'un film avec un code temporel défini par la "Society of Motion Picture and Television Engineers". Les codes temporels sont ajoutés au film, à la vidéo ou au matériel audio et ont également été adaptés pour synchroniser la musique. Ils fournissent une référence temporelle pour le montage, la synchronisation et l'identification.
 
 **Snap Mode**
 : Les menus **Snap Mode** e trouvent juste en dessous des **Clocks**. Ils controlent le degré de **Quantization** de la grille de temps, par exemple, le degré de "snap" q'une **Région** audio a par rapoort au type de grille choisi.

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -455,69 +455,47 @@ sound which is heard as one **Octave**(+12 MIDI notes) above another one
 is twice the frequency in Hz, while a sound one octave below (-12 MIDI
 notes) is half the frequency.
 
-**Playhead**
-: In Ardour, the Playhead is the red line that moves in time (i.e., left
-to right) to indicate the current playback position. 
+**Tête de lecture**
+: Dans Ardour, la tête de lecture est la ligne rouge qui se déplace dans le temps (c'est-à-dire de gauche à droite) pour indiquer la position de lecture actuelle.
 
-**Plugin**
-: In computing, a plugin consists of a computer program that interacts
-with a host application (in this case, Ardour) to provide a certain
-function "on demand", usually a very specific one. Reverb, filters, and
-equalizers are examples of plugins that can be used in Ardour in
-association with Tracks or Busses.
+**Greffon** (Plugin)
+: En informatique, un greffon est un programme informatique qui interagit avec une application hôte (dans le cas présent, Ardour) pour fournir certaines fonctionnalités.
+La réverbération, les filtres et les égaliseurs sont des exemples de greffons qui peuvent être utilisés dans Ardour en association avec des pistes ou des bus.
 
 **Portaudio**
-: A free and open source set of **audio drivers**for Linux and macOS.
+: Un ensemble de **pilotes audio** libres et gratuits pour Linux et macOS.
 
-**Post-Fader** (Plugin or Send)
-: In the Mixer Strip, the post-fader area is the black space below the
+**Post-atténuateur** (greffon ou départ)
+: Dans la bande de mixage, la zone post-atténuateur est l'espace noir situé sous le curseur de gain, auquel des greffons ou des départs peuvent être ajoutés. L'entrée de ces greffons et envois sera le signal *après* tout changement de gain manuel ou automatisé (d'où le terme "post-atténuateur").
+In the Mixer Strip, the post-fader area is the black space below the
 gain slider, to which plugins or sends can be added. The input of these
 plugins and sends will be the signal *after* any manual or automated
 gain change (thus "post-fader"). 
 
-**Pre-Fader** (Plugin or Send)
-: In the Mixer Strip, the pre-fader area is the black space above the gain
-slider, to which plugins or sends can be added. The input of these
-plugins and sends will be the incoming signal *before* it is affected by
-any manual or automated gain changes controlled by the slider (thus
-"pre-fader").
+**Pre-attnuateur** (greffon ou départ)
+: Dans la bande de mixage, la zone de pré-atténuateur est l'espace noir au-dessus de curseur de gain, auquel des greffons ou des départs peuvent être ajoutés. L'entrée de ces
+greffons et envois sera le signal entrant *avant* qu'il ne soit affecté par tout changement de gain manuel ou automatisé contrôlé par le curseur (donc "pré-atténuateur").
 
 **Quantization**
-: In signal processing, quantization may refer to bit depth (see **bit
-depth** definition). In MIDI, quantization refers to the process of
-aligning notes to a precise temporal grid. This results in notes being
-set on beats or exact fractions of beats. MIDI sequencers typically
-include some type of quantization function.
+: Dans le traitement des signaux, la quantification peut se référer à la profondeur de bits (voir la définition de **profondeur de bits**). En MIDI, la quantification fait référence au processus d'alignement des notes sur une grille temporelle précise. Il en résulte que les notes sont sur des temps ou des fractions exactes de temps. Les séquenceurs MIDI comprennent généralement une fonction de quantification.
 
 **Range**
-: A segment of time. Ranges are created with the Select/Move Ranges tool
-and may include one or more tracks. Loop and punch ranges are special
-types of ranges that are created and manipulated with the loop/punch
-ranges meter.
+: Un segment de temps. Les intervalles sont créés à l'aide de l'outil Sélectionner/Déplacer les intervalles et peuvent inclure une ou plusieurs pistes. Les Intervalles de boucles et de punch sont des types d'intervalles spéciaux qui sont créés et manipulés avec l'indicateur d'intervalle boucle/punch
 
 **Real-time System**(Linux)
-: In a **Real-time System**, the **Linux kernel** is usually recompiled
-(rebuilt) with new parameters, and other settings in the system are
-optimized which speed up the use of audio applications in the system.
+: Dans un **Real-time System**, Le **Linux kernel** est généralement recompilé
+(reconstruit) avec de nouveaux paramètres, et d'autres paramètres du système sont optimisés, ce qui accélère l'utilisation des applications audio dans le système.
 
 **Regions**
-: Regions are the basic elements of editing and composing in Ardour. Each
-region represents all or part of an audio file. Removing a region from a
-track does not remove the audio file from the disk.
+: Les régions sont les éléments de base de l'édition et de la composition dans Ardour. Chaque
+région représente tout ou partie d'un fichier audio. La suppression d'une région n'enlève pas le fichier audio du disque.
 
 **Region List**
-: The region list is located at the right hand side of the Editor Window
-and it shows all the regions associated with the session. 
+: La liste des régions se trouve à droite de la fenêtre de l'éditeur et affiche toutes les régions associées à la session.
 
 **Reverberation**
-: Reverberation is the persistence of sound in a particular space after
-the original sound source is
-removed.^[](http://en.wikipedia.org/wiki/Reverberation#cite_note-0)^^^A
-reverberation, or reverb, is created when a sound is produced in an
-enclosed space causing a large number of echoes to build up and then
-slowly decay as the sound is absorbed by the walls and air. Digital
-reverberation can be added to a sound in Ardour through the use of
-plugins. 
+: La réverbération est la persistance du son dans un espace particulier après que la source sonore d'origine ce soit tue.^[](http://en.wikipedia.org/wiki/Reverberation#cite_note-0)^^^
+Une réverbération est créée lorsqu'un son est produit dans un espace clos, ce qui provoque l'apparition d'un grand nombre d'échos, puis, lentement, au fur et à mesure, le son est absorbé par les murs et l'air. La réverbération numérique peut être ajoutée à un son dans Ardour grâce à l'utilisation de greffons.
 
 **Right Click** (souris)
 : Cliquez sur le bouton droit de la souris.

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -103,35 +103,22 @@ La fréquence centrale d'une bande sera celle qui sera la plus fortement atténu
 Lorsque le bouton droit est requis, l'action est appelée "clic droit".
 
 **Clipping**
-: Clipping occurs when a signal is too high in level to be reproduced. Any
-samples too high in level will simply be truncated, resulting in
-_distortion_, loss of audio detail, and artefact _frequencies_ which
-were not present in the original sound.
+: L'écrêtage se produit lorsqu'un signal est trop élevé pour être reproduit. Tous les échantillons trop élevés seront simplement tronqués, ce qui entraîne une _distorsion_, une perte de détails audio et des artefacts de _fréquences_ qui n'étaient pas présents dans le son original.
 
 **Clipping Point**
-: The clipping point of a digital system is referred to as 0 dB, and
-the level of any sound is measured in how far below the clipping point
-it is (-10 dB, -24 dB, etc).
+: Le point d'écrêtage d'un système numérique est appelé 0 dB.
+Le niveau d'un son est mesuré en fonction de la distance qui le sépare du point d'écrêtage (-10 dB, -24 dB, etc.).
 
 **Clocks**
-: The two big numerical displays near the top of the _Editor_ window. They can
-display the time in a number of formats: _Timecode_, _Bars:Beats_,
-_Minutes:Seconds_, and _Samples_.
+: les deux gros afficheurs numériques en haut de la fenêtre _Editor_.
+Il peuvent affiche le temps dans un certain nombre de formats : _Timecode_, _Bars:Beats_, _Minutes:Seconds_, et _Samples_.
 
 **Compile**
-: FLOSS applications are distributed as source code, which is human-readable but
-cannot be run as an actual application. To turn this source code into a running
-application, it must first be Compiled. When you download a disk image for macOS
-or a software package from your distribution (such as Ubuntu, Debian or Fedora),
-it has been compiled for you already. However, if you wish to add features (such
-as support for _VST Plugins_) which your distribution does not provide, then
-you must compile the application from source code yourself. 
+: Les applications FLOSS sont distribuées sous forme de code source, qui est lisible par l'homme mais ne peut pas être exécuté comme une application réelle. Pour transformer ce code source en une application il doit d'abord être compilé. Lorsque vous téléchargez une image disque pour macOS ou un paquetage logiciel de votre distribution (comme Ubuntu, Debian ou Fedora), il a déjà été compilé pour vous. Cependant, si vous souhaitez ajouter des fonctionnalités (telles que la prise en charge des _VST Plugins_) que votre distribution ne fournit pas, alors vous devez compiler vous-même l'application à partir du code source.
 
 **Compression**(DSP)
-: Essentially, compression makes the quiet parts of a signal louder
-without changing the level of 
-the louder parts. This entails a reduction of the actual dynamic range:
-a compressed sound is less dynamic (has a smaller range of levels) 
+: Essentiellement, la compression rend les parties calmes d'un signal plus bruyantes sans modifier le niveau des parties 
+les parties les plus bruyantes. Cela entraîne une réduction de la plage dynamique réelle : un son compressé est moins dynamique.
 
 **Compression** (data)
 : Like any other data, audio data can be compressed so that it uses less

--- a/content/appendices/glossary/index.fr.md
+++ b/content/appendices/glossary/index.fr.md
@@ -601,101 +601,67 @@ material, and have also been adapted to synchronize music. They provide
 a time reference for editing, synchronization and identification.
 
 **Snap Mode**
-: The **Snap Mode** menus are found just below the **Clocks**. They
-control the amount **Quantization** of the time grid, i.e., the amount
-of "snap" an audio **Region** has to the type of grid you have chosen.
+: Les menus **Snap Mode** e trouvent juste en dessous des **Clocks**. Ils controlent le degré de **Quantization** de la grille de temps, par exemple, le degré de "snap" q'une **Région** audio a par rapoort au type de grille choisi.
 
 **Snapshots**
-: Saving a snapshot in Ardour is similar to saving the session to a new
-file to avoid overwriting the original session file. A snapshot contains
-the current state of your work, while sharing all the audio and data
-files of the Session. If you were trying to find a "Save As" function in
-Ardour, saving a snapshot is probably what you are looking for. 
+: L'enregistrement d'un instantané dans Ardour est similaire à l'enregistrement de la session dans un nouveau fichier afin d'éviter d'écraser le fichier de session d'origine.
+Un instantané contient l'état actuel de votre travail, tout en partageant tous les fichiers audio et de données de la session. Si vous essayez de trouver une fonction "Enregistrer sous" dans Ardour, l'enregistrement d'un instantané est probablement ce que vous recherchez. 
 
 **Solo**
-: Toggle switch found in track controls and mixer strips. When toggled on,
-only solo tracks will send output. Several tracks can be marked solo at
-once. The general Solo button (top row of controls in the Editor Window)
-can be used to un-solo all soloed tracks at once.
+: Interrupteur à bascule que l'on trouve dans les commandes de piste et les bandes de mixage. Lorsqu'il est activé, seules les pistes solo enverront une sortie. Plusieurs pistes peuvent être marquées comme plusieurs pistes à la fois. Le bouton Solo général (rangée supérieure de commandes dans la fenêtre d'édition) peut être utilisé pour annuler la mise en solo de toutes les pistes en solo en même temps.
 
 **Spectrum**
-: The representation of a signal in terms of its frequency components. 
+: La représentation d'un signal en termes de ses composantes de fréquence. 
 
 **Stereo**
-: A stereo sound file contains two channels of audio (usually known as
-Left and Right channels). A stereo track in Ardour has two inputs and
-outputs, in order to record and playback stereo files.
+: Un fichier audio stéréo contient deux canaux audio (généralement appelés canaux gauche et droit). Une piste stéréo dans Ardour possède deux entrées et deux sorties afin d'enregistrer et de lire des fichiers stéréo.
 
 **Stereo Field**
-: Stereo field is the perception of spatial location of sounds based on a
-sound reproduction system of 2 channels (Left and Right). 
+: Le champ stéréophonique est la perception de la localisation spatiale des sons basée sur un système de reproduction sonore à deux canaux (gauche et droit).
 
 **Take**(recording)
-: A sequence of sound recorded continuously at one time.
+: Une séquence de sons enregistrée en une fois.
 
 **Tape Mode**
-: See **Track Mode**. 
+: Voir **Track Mode**. 
 
 **Tempo**(music)
-: The rate at which beats occur. Precise Tempo indications are measured in
-**bpm** (beats per minute), although subjective indications are also
-common in scores (Allegro, Adagio, Very Fast, etc). 
+: La vitesse à laquelle les battements se produisent. Les indications précises de tempo sont mesurées en **bpm** (battements par minute), bien que des indications subjectives soient également subjectives sont également courantes dans les partitions (Allegro, Adagio, Très rapide, etc.).
 
 **Terminal**
-: A "terminal" is the text-based interface that allows to operate a
-computer by typing commands into it. Most computer users today rely
-solely on a graphical interface to control their systems. Both macOS
-and Linux though, include a terminal which may make some tasks easier
-for some users. 
+: Un "terminal" est l'interface textuelle qui permet d'utiliser un ordinateur en y tapant des commandes. Aujourd'hui, la plupart des utilisateurs d'ordinateurs uniquement sur une interface graphique pour contrôler leurs systèmes. macOS et Linux incluent un terminal qui peut faciliter certaines tâches pour certains utilisateurs.
 
 **Timecode**
-: A time code is a sequence of numeric codes generated at regular
-intervals by a timing system. The SMPTE family of timecodes is almost
-universally used in film, video and audio production.
+: Un code temporel est une séquence de codes numériques générés à intervalles réguliers par un système de synchronisation. La famille des timecodes SMPTE est presque universellement utilisée dans la production cinématographique, vidéo et audio.
 
-**Time Signature** (music) 
-: A sign placed at the start of a piece of music (after the clef and key
-signature) or during the course of it, indicating the meter of the
-music.
+**Time Signature** (musique) 
+: Signe placé au début d'un morceau de musique (après la clef et l'armure) ou au cours de celui-ci, indiquant la mesure du morceau.
 
 **Track**
-: A Track is the place to where you can drag a **Region** from your
-**Region List**and where you can record sounds coming from an
-outside source. The Mixer Strip vertically represents the signal flow of
-a track, whereas the Main Canvas horizontally displays time-based
-information for each track. 
+: Une piste est un endroit où vous pouvez glisser une **Région** depuis votre **Liste de Régions** et où vous pouvez enreistrer des son qui viennent d'une source externe.
+La bande de mixage représente verticalement le flux de signal d'une piste, tandis que le canevas principal affiche horizontalement des informations
+pour chaque piste.
 
 **Track Mode**
-: **Track Mode** gives you a choice between **Normal Mode** and **Tape
-Mode**. Normal Mode creates a new Region for each Recording **Take**,
-while **Tape Mode** destructively records--in other words the previous
-Take of a Track is eliminated with each new Take.
+: **Track Mode** vous donne le choix entre **Normal Mode** et **Tape
+Mode**. Normal Mode crée une nouvelle région pour chaque enregistrement **Take**,
+alors que **Tape Mode** enregistre par dessus, la prise précédente de la piste est éliminée par chaque nouvelle prise.
 
 **Transport**
-: The buttons located on the upper left corner of the Editor Window, with
-controls such as Rewind, Play, Stop. 
+: Les boutons situés dans le coin supérieur gauche de la fenêtre de l'éditeur, avec des commandes telles que Rewind, Play, Stop.
 
-**Treble**(frequencies)
-: Generic way of referring to high frequencies of the **Spectrum** of a
-sound.
+**Treble**(fréquences)
+: Façon générique de désigner les hautes fréquences du **Spectre** d'un son.
 
 **VST (Virtual Studio Technology)**
-: [Steinberg](http://en.wikipedia.org/wiki/Steinberg) VST is an
-interface for integrating software audio synthesizer and effect plugins
-with audio editors and digital workstations such as Ardour. VST and
-similar technologies use digital signal processing to simulate
-traditional recording studio hardware with software. Thousands of
-plugins exist, both commercial and freeware. VST was created by
-Steinberg. 
+: [Steinberg](http://en.wikipedia.org/wiki/Steinberg) VST est une interface permettant d'intégrer des synthétiseurs audio logiciels et des plugins d'effets dans des éditeurs audio et des stations de travail numériques comme Ardour. VST et les technologies similaires utilisent le traitement des signaux numériques pour simuler le matériel traditionnel d'un studio d'enregistrement avec un logiciel. Des milliers de greffons existent, qu'ils soient commerciaux ou gratuits. VST a été créé par Steinberg. 
 
 **WAV**
-: A sound file format developed by Microsoft and IBM and commonly used for
-lossless and uncompressed audio. WAV files are compatible with Windows,
-Macintosh and Linux operating systems.
+: Format de fichier audio développé par Microsoft et IBM et couramment utilisé pour les fichiers audio non compressés et sans perte. Les fichiers WAV sont compatibles avec les systèmes d'exploitation Windows, Macintosh et Linux.
 
 **Waveform**
-: The time-domain visual representation of a sound. Waveforms are drawn
-inside the colored rectangles representing Regions in the Main Canvas.
+: Représentation visuelle d'un son dans le domaine temporel. Les formes d'onde sont dessinées
+à l'intérieur des rectangles colorés représentant les régions dans le canevas principal.
 
 **Word length**
-: See **Bit Depth**. 
+: Voir **Bit Depth**. 


### PR DESCRIPTION
The goal is to translate all the glossary without titles first.
After that, translate title by title and report in all the tutorial pages according to what is translated in Ardour graphical user interface.
Let's do the first step ...

Draft for now.