### PR TITLE
Fix 'Importing audio' links in 'Getting started' page

### DIFF
--- a/content/getting-started/_index.en.md
+++ b/content/getting-started/_index.en.md
@@ -15,5 +15,5 @@ Contents:
 1. [Starting Ardour](starting-ardour/)
 2. [Overview of the interface](overview-of-the-interface/)
 3. [Creating tracks and busses](creating-tracks-and-busses/)
-4. [Importing audio](importing-audio/)
+4. [Importing audio](importing-audio-and-midi/)
 5. [Setting up the timeline](setting-up-the-timeline/)

--- a/content/getting-started/_index.en.md
+++ b/content/getting-started/_index.en.md
@@ -15,5 +15,5 @@ Contents:
 1. [Starting Ardour](starting-ardour/)
 2. [Overview of the interface](overview-of-the-interface/)
 3. [Creating tracks and busses](creating-tracks-and-busses/)
-4. [Importing audio](importing-audio-and-midi/)
+4. [Importing audio and MIDI](importing-audio-and-midi/)
 5. [Setting up the timeline](setting-up-the-timeline/)

--- a/content/getting-started/_index.fr.md
+++ b/content/getting-started/_index.fr.md
@@ -15,5 +15,5 @@ Contenu :
 1. [Démarrer Ardour](starting-ardour/)
 2. [Vue d'ensemble de l'interface](overview-of-the-interface/)
 3. [Création de pistes et de bus](creating-tracks-and-busses/)
-4. [Import audio](importing-audio/)
+4. [Import audio](importing-audio-and-midi/)
 5. [Configuration de la ligne de temps](setting-up-the-timeline/)

--- a/content/getting-started/_index.fr.md
+++ b/content/getting-started/_index.fr.md
@@ -15,5 +15,5 @@ Contenu :
 1. [Démarrer Ardour](starting-ardour/)
 2. [Vue d'ensemble de l'interface](overview-of-the-interface/)
 3. [Création de pistes et de bus](creating-tracks-and-busses/)
-4. [Import audio](importing-audio-and-midi/)
+4. [Import audio et MIDI](importing-audio-and-midi/)
 5. [Configuration de la ligne de temps](setting-up-the-timeline/)

--- a/content/getting-started/_index.ru.md
+++ b/content/getting-started/_index.ru.md
@@ -15,5 +15,5 @@ pre = "<b>2. </b>"
 1. [Запуск Ardour](starting-ardour/)
 2. [Обзор интерфейса](overview-of-the-interface/)
 3. [Создание дорожек и шин](creating-tracks-and-busses/)
-4. [Импорт звуковых файлов](importing-audio-and-midi/)
+4. [Импорт аудио и MIDI](importing-audio-and-midi/)
 5. [Настройка таймлайна](setting-up-the-timeline/)

--- a/content/getting-started/_index.ru.md
+++ b/content/getting-started/_index.ru.md
@@ -15,5 +15,5 @@ pre = "<b>2. </b>"
 1. [Запуск Ardour](starting-ardour/)
 2. [Обзор интерфейса](overview-of-the-interface/)
 3. [Создание дорожек и шин](creating-tracks-and-busses/)
-4. [Импорт звуковых файлов](importing-audio/)
+4. [Импорт звуковых файлов](importing-audio-and-midi/)
 5. [Настройка таймлайна](setting-up-the-timeline/)

--- a/content/getting-started/_index.ru.md
+++ b/content/getting-started/_index.ru.md
@@ -15,5 +15,5 @@ pre = "<b>2. </b>"
 1. [Запуск Ardour](starting-ardour/)
 2. [Обзор интерфейса](overview-of-the-interface/)
 3. [Создание дорожек и шин](creating-tracks-and-busses/)
-4. [Импорт аудио и MIDI](importing-audio-and-midi/)
+4. [Импорт звуковых и MIDI-файлов](importing-audio-and-midi/)
 5. [Настройка таймлайна](setting-up-the-timeline/)


### PR DESCRIPTION
In the [Getting started](https://prokoudine.github.io/ardour-tutorial/en/getting-started/) page, the link for "Importing audio" [does not exist](https://prokoudine.github.io/ardour-tutorial/en/getting-started/importing-audio/). However, I was able to find (what I suspect to be) [the desired page](https://prokoudine.github.io/ardour-tutorial/en/getting-started/importing-audio-and-midi/) exists in the project.

This change fixes the "Importing audio" links for the Getting started page for all present languages. Below is a short video demonstrating the fix.

[link_fix_before_and_after.webm](https://github.com/prokoudine/ardour-tutorial/assets/3261001/50be4257-c020-4817-af9c-9e1966cb6be1)
