### PR TITLE
fixed links in basics

### DIFF
--- a/content/basics/_index.fr.md
+++ b/content/basics/_index.fr.md
@@ -8,5 +8,5 @@ cascade:
 
 Si vous êtes novice en matière d'enregistrement et de production musicale, voici quelques points à connaître avant de commencer à apprendre Ardour :
 
-- [Qu'est-ce que l'audio numérique?](/fr/basics/audio/)
-<!-- - [Qu'est-ce que le MIDI?](/fr/basics/midi) -->
+- [Qu'est-ce que l'audio numérique?](audio/)
+<!-- - [Qu'est-ce que le MIDI?](midi/) -->

--- a/content/basics/_index.md
+++ b/content/basics/_index.md
@@ -8,5 +8,5 @@ cascade:
 
 If you are new to recording and producing music, here are some things you need to know before you start learning Ardour:
 
-- [What is digital audio?](/basics/audio)
-- [What is MIDI?](/basics/midi)
+- [What is digital audio?](audio/)
+- [What is MIDI?](midi/)


### PR DESCRIPTION
Before the fix when clicking links in main view of

https://prokoudine.github.io/ardour-tutorial/basics/

they were taking me to
https://prokoudine.github.io/basics/audio
and
https://prokoudine.github.io/basics/midi
which both lack /ardour-tutorial prefix so were resulting in a 404 error.
This PR is meant to fix it.
