### PR TITLE
Fix broken links to plugins page

### DIFF
--- a/content/getting-started/installing-plugins/index.en.md
+++ b/content/getting-started/installing-plugins/index.en.md
@@ -17,7 +17,7 @@ Ardour supports mutiple plugins APIs:
 - **macOS**: LADSPA, LV2, VST2.x, VST3, AU
 
 You can find a list of recommended free/libre plugins
-[in the appendix](../../appendices/plugins/).
+[in the mixing section](../../mixing-sessions/plugins/).
 
 ## Installing plugins
 
@@ -38,13 +38,13 @@ VST2 plugins do not have vendor-recommended location for installation, so what
 you can do is:
 
 1. Unpack all your VST2.x plugins to the same folder. (On Linux, `~/.vst` is
-commonly suggested.)
+   commonly suggested.)
 
 2. In Ardour, go to _Edit > Preferences > Plugins > VST_ and in the VST2.x
-section, click the **Edit** button to add a new path to VST2.x plugins.
+   section, click the **Edit** button to add a new path to VST2.x plugins.
 
 3. Add the path to the folder you created in step 1. Ardour will ask if you
-want to rescan plugins. Say 'yes'.
+   want to rescan plugins. Say 'yes'.
 
 This approach works on each supported operating system.
 

--- a/content/getting-started/installing-plugins/index.fr.md
+++ b/content/getting-started/installing-plugins/index.fr.md
@@ -15,7 +15,7 @@ Ardour supporte plusieurs API de greffons :
 - **Windows** : LADSPA, LV2, VST2.x, VST3
 - **macOS** : LADSPA, LV2, VST2.x, VST3, AU
 
-Vous pouvez trouver une liste de greffons libres/libre recommandés [en annexe](../../appendices/plugins/).
+Vous pouvez trouver une liste de greffons libres/libre recommandés [dans la section mixage](../../mixing-sessions/plugins/).
 
 ## Installation des greffons
 
@@ -36,12 +36,12 @@ Les greffons VST2 n'ont pas d'emplacement recommandé par le vendeur pour l'inst
 Ce que vous pouvez faire, c'est :
 
 1. Décompresser tous vos greffons VST2.x dans le même dossier.
-(Sous Linux, `~/.vst` est généralement suggéré).
+   (Sous Linux, `~/.vst` est généralement suggéré).
 
 2. Dans Ardour, allez dans `Editer > Préférences > greffons > VST` et dans la section VST2.x, cliquez sur le bouton **Editer** pour ajouter un nouveau chemin pour les greffons VST2.x.
 
 3. Ajoutez le chemin vers le dossier que vous avez créé à l'étape 1.
-Ardour vous demandera si vous si vous voulez rescanner les greffons. Dites "oui".
+   Ardour vous demandera si vous si vous voulez rescanner les greffons. Dites "oui".
 
 Cette approche fonctionne sur tous les systèmes d'exploitation pris en charge.
 


### PR DESCRIPTION
Fixed the broken links in both the English and French versions of the Ardour tutorial website:
  - The original links were pointing to a non-existent directory path: ../../appendices/plugins/
  - The recommended plugins information actually exists in the mixing-sessions section at ../../mixing-sessions/plugins/
  -Updated both the English and French versions of the installing-plugins page to point to the correct location