### PR TITLE
Fix broken Geonkick link

### DIFF
--- a/content/mixing-sessions/plugins/index.en.md
+++ b/content/mixing-sessions/plugins/index.en.md
@@ -26,7 +26,7 @@ While Ardour ships with a series of basic plugins, there are more free-as-in-spe
 
 - [AVL Drumkits](https://x42-plugins.com/x42/x42-avldrums), a drum sampler with two built-in kits
 - [DrumGizmo](https://drumgizmo.org), a drum sampler with separately downloadable kits
-- [Geonkick](https://github.com/free-sm/geonkick), a drums/percussion synthesizer
+- [Geonkick](https://quamplex.com/geonkick), a drums/percussion synthesizer
 
 ## Synthesizers
 

--- a/content/mixing-sessions/plugins/index.fr.md
+++ b/content/mixing-sessions/plugins/index.fr.md
@@ -25,7 +25,7 @@ Ardour est livré avec une série de plugins de base, mais il existe d'autres pl
 
 - [AVL Drumkits](https://x42-plugins.com/x42/x42-avldrums), un échantillonneur de batterie avec deux kits intégrés
 - [DrumGizmo](https://drumgizmo.org), un échantillonneur de batterie avec des kits à télécharger séparément
-- [Geonkick](https://github.com/free-sm/geonkick), un synthétiseur batterie/percussion
+- [Geonkick](https://quamplex.com/geonkick), un synthétiseur batterie/percussion
 
 ## Synthétiseurs
 

--- a/content/mixing-sessions/plugins/index.it.md
+++ b/content/mixing-sessions/plugins/index.it.md
@@ -27,7 +27,7 @@ shelfing e alto & passa-basso
 
 - [AVL Drumkits](https://x42-plugins.com/x42/x42-avldrums), un campionatore di batteria con due kit integrati
 - [DrumGizmo](https://drumgizmo.org), un campionatore di batteria con kit scaricabili separatamente
-- [Geonkick](https://github.com/free-sm/geonkick), un sintetizzatore di batteria/percussioni
+- [Geonkick](https://quamplex.com/geonkick), un sintetizzatore di batteria/percussioni
 
 ## Sintetizzatori
 


### PR DESCRIPTION
The Geonkick link to https://github.com/free-sm/geonkick on the "Recommended plugins" page is broken.